### PR TITLE
Ignore hidden files on OSX

### DIFF
--- a/Project.js
+++ b/Project.js
@@ -144,7 +144,7 @@ class Project {
 						type = 'video';
 					}
 
-					if (!name.startsWith('.')) {
+					if (!name.startsWith('.') && name.length > 0) {
 						this.assets.push({
 							name: name,
 							file: stringify(file),


### PR DESCRIPTION
Turns out those .DS_STOREs are reported as empty strings