### PR TITLE
Support for windowOptions and targetOptions in khafile.js

### DIFF
--- a/AndroidExporter.js
+++ b/AndroidExporter.js
@@ -31,7 +31,7 @@ class AndroidExporter extends KhaExporter {
 		return "Android";
 	}
 
-	exportSolution(name, platform, khaDirectory, haxeDirectory, from, callback) {
+	exportSolution(name, platform, khaDirectory, haxeDirectory, from, _targetOptions, callback) {
 		const safename = name.replaceAll(' ', '-');
 
 		const defines = [

--- a/CSharpExporter.js
+++ b/CSharpExporter.js
@@ -30,7 +30,7 @@ class CSharpExporter extends KhaExporter {
 		}
 	}
 
-	exportSolution(name, platform, khaDirectory, haxeDirectory, from, callback) {
+	exportSolution(name, platform, khaDirectory, haxeDirectory, from, _targetOptions, callback) {
 		this.addSourceDirectory("Kha/Backends/" + this.backend());
 
 		const defines = [

--- a/FlashExporter.js
+++ b/FlashExporter.js
@@ -33,7 +33,7 @@ class FlashExporter extends KhaExporter {
 		return 'flash';
 	}
 
-	exportSolution(name, platform, khaDirectory, haxeDirectory, from, callback) {
+	exportSolution(name, platform, khaDirectory, haxeDirectory, from, targetOptions, callback) {
 		let defines = [
 			'swf-script-timeout=60',
 			'sys_' + platform,
@@ -42,6 +42,14 @@ class FlashExporter extends KhaExporter {
 		];
 		if (this.embed) defines.push('KHA_EMBEDDED_ASSETS');
 
+		let defaultFlashOptions = {
+			framerate : 60,
+			stageBackground : 'ffffff',
+			swfVersion : '16.0'
+		}
+		
+		let flashOptions = targetOptions ? targetOptions.flash ? targetOptions.flash : defaultFlashOptions : defaultFlashOptions;
+		
 		const options = {
 			from: from.toString(),
 			to: path.join(this.sysdir(), 'kha.swf'),
@@ -53,7 +61,10 @@ class FlashExporter extends KhaExporter {
 			language: 'as',
 			width: this.width,
 			height: this.height,
-			name: name
+			name: name,
+			framerate: 'framerate' in flashOptions ? flashOptions.framerate : defaultFlashOptions.framerate,
+			stageBackground: 'stageBackground' in flashOptions ? flashOptions.stageBackground : defaultFlashOptions.stageBackground,
+			swfVersion : 'swfVersion' in flashOptions ? flashOptions.swfVersion : defaultFlashOptions.swfVersion
 		};
 		HaxeProject(this.directory.toString(), options);
 

--- a/HaxeProject.js
+++ b/HaxeProject.js
@@ -109,7 +109,8 @@ function hxml(projectdir, options) {
 	}
 	else if (options.language === 'as') {
 		data += '-swf ' + path.normalize(options.to) + '\n';
-		data += '-swf-version 16.0\n';
+		data += '-swf-version ' + options.swfVersion + '\n';
+		data += '-swf-header ' + options.width + ':' + options.height + ':' + options.framerate + ':' + options.stageBackground + '\n'
 	}
 	for (let param of options.parameters) {
 		data += param + '\n';
@@ -139,6 +140,8 @@ function FlashDevelop(projectdir, options) {
 			break;
 	}
 
+	let swfVersion = parseFloat(options.swfVersion).toString().split('.');
+	
 	let output = {
 		n: 'output',
 		e: [
@@ -156,7 +159,7 @@ function FlashDevelop(projectdir, options) {
 			},
 			{
 				n: 'movie',
-				fps: 60
+				fps: options.framerate
 			},
 			{
 				n: 'movie',
@@ -168,11 +171,11 @@ function FlashDevelop(projectdir, options) {
 			},
 			{
 				n: 'movie',
-				version: 16
+				version: swfVersion[0]
 			},
 			{
 				n: 'movie',
-				minorVersion: 0
+				minorVersion: swfVersion[1]
 			},
 			{
 				n: 'movie',
@@ -180,7 +183,7 @@ function FlashDevelop(projectdir, options) {
 			},
 			{
 				n: 'movie',
-				background: '#FFFFFF'
+				background: '#' + options.stageBackground
 			}
 		]
 	};

--- a/Html5Exporter.js
+++ b/Html5Exporter.js
@@ -22,7 +22,7 @@ class Html5Exporter extends KhaExporter {
 		return 'html5';
 	}
 
-	exportSolution(name, platform, khaDirectory, haxeDirectory, from, callback) {
+	exportSolution(name, platform, khaDirectory, haxeDirectory, from, _targetOptions, callback) {
 		this.createDirectory(this.directory.resolve(this.sysdir()));
 
 		let defines = [

--- a/JavaExporter.js
+++ b/JavaExporter.js
@@ -21,7 +21,7 @@ class JavaExporter extends KhaExporter {
 		return 'java';
 	}
 
-	exportSolution(name, platform, khaDirectory, haxeDirectory, from, callback) {
+	exportSolution(name, platform, khaDirectory, haxeDirectory, from, _targetOptions, callback) {
 		this.addSourceDirectory("Kha/Backends/" + this.backend());
 
 		this.createDirectory(this.directory.resolve(this.sysdir()));

--- a/KoreExporter.js
+++ b/KoreExporter.js
@@ -24,7 +24,7 @@ class KoreExporter extends KhaExporter {
 		return this.platform;
 	}
 
-	exportSolution(name, platform, khaDirectory, haxeDirectory, from, callback) {
+	exportSolution(name, platform, khaDirectory, haxeDirectory, from, _targetOptions, callback) {
 		let defines = [
 			'no-compilation',
 			'sys_' + platform,

--- a/Project.js
+++ b/Project.js
@@ -65,6 +65,11 @@ class Project {
 		this.parameters = [];
 		this.scriptdir = Project.scriptdir;
 		this.libraries = [];
+		
+		this.windowOptions = {}		
+		this.targetOptions = {
+			flash : {}
+		}
 	}
 
 	/**

--- a/UnityExporter.js
+++ b/UnityExporter.js
@@ -22,7 +22,7 @@ class UnityExporter extends KhaExporter {
 		return 'unity';
 	}
 
-	exportSolution(name, platform, khaDirectory, haxeDirectory, from, callback) {
+	exportSolution(name, platform, khaDirectory, haxeDirectory, from, _targetOptions, callback) {
 		this.addSourceDirectory("Kha/Backends/Unity");
 
 		const defines = [

--- a/main.js
+++ b/main.js
@@ -207,8 +207,8 @@ function exportAssets(assets, exporter, from, khafolders, platform, encoders) {
 	}
 }
 
-function exportProjectFiles(name, from, to, options, exporter, platform, khaDirectory, haxeDirectory, kore, libraries, callback) {
-	if (haxeDirectory.path !== '') exporter.exportSolution(name, platform, khaDirectory, haxeDirectory, from, function () {
+function exportProjectFiles(name, from, to, options, exporter, platform, khaDirectory, haxeDirectory, kore, libraries, targetOptions, callback) {
+	if (haxeDirectory.path !== '') exporter.exportSolution(name, platform, khaDirectory, haxeDirectory, from, targetOptions, function () {
 		if (haxeDirectory.path !== '' && kore) {
 			{
 				fs.copySync(pathlib.join(__dirname, 'Data', 'build-korefile.js'), pathlib.join(to.resolve(exporter.sysdir() + "-build").toString(), 'korefile.js'));
@@ -351,8 +351,20 @@ function exportKhaProject(from, to, platform, khaDirectory, haxeDirectory, oggEn
 	}
 
 	name = project.name;
-	exporter.setWidthAndHeight(800, 600); // project.game.width, project.game.height);
+	
+	let defaultWindowOptions = {
+		width : 800,
+		height : 600
+	}
+	
+	let windowOptions = project.windowOptions ? project.windowOptions : defaultWindowOptions;
+	
 	exporter.setName(name);
+	exporter.setWidthAndHeight(
+		'width' in windowOptions ? windowOptions.width : defaultWindowOptions.width,
+		'height' in windowOptions ? windowOptions.height : defaultWindowOptions.height
+	);
+	
 	for (let source of project.sources) {
 		exporter.addSourceDirectory(source);
 	}
@@ -424,10 +436,10 @@ function exportKhaProject(from, to, platform, khaDirectory, haxeDirectory, oggEn
 			if (foundProjectFile) {
 				fs.outputFileSync(to.resolve(Paths.get(exporter.sysdir() + '-resources', 'files.json')).toString(), JSON.stringify({ files: files }, null, '\t'), { encoding: 'utf8' });
 				log.info('Assets done.');
-				exportProjectFiles(name, from, to, options, exporter, platform, khaDirectory, haxeDirectory, kore, project.libraries, callback);
+				exportProjectFiles(name, from, to, options, exporter, platform, khaDirectory, haxeDirectory, kore, project.libraries, project.targetOptions, callback);
 			}
 			else {
-				exportProjectFiles(name, from, to, options, exporter, platform, khaDirectory, haxeDirectory, kore, project.libraries,callback);
+				exportProjectFiles(name, from, to, options, exporter, platform, khaDirectory, haxeDirectory, kore, project.libraries, project.targetOptions, callback);
 			}
 		}
 	}
@@ -435,10 +447,10 @@ function exportKhaProject(from, to, platform, khaDirectory, haxeDirectory, oggEn
 	if (foundProjectFile) {
 		fs.outputFileSync(to.resolve(Paths.get(exporter.sysdir() + '-resources', 'files.json')).toString(), JSON.stringify({ files: files }, null, '\t'), { encoding: 'utf8' });
 		log.info('Assets done.');
-		exportProjectFiles(name, from, to, options, exporter, platform, khaDirectory, haxeDirectory, kore, project.libraries, secondPass);
+		exportProjectFiles(name, from, to, options, exporter, platform, khaDirectory, haxeDirectory, kore, project.libraries, project.targetOptions, secondPass);
 	}
 	else {
-		exportProjectFiles(name, from, to, options, exporter, platform, khaDirectory, haxeDirectory, kore, project.libraries, secondPass);
+		exportProjectFiles(name, from, to, options, exporter, platform, khaDirectory, haxeDirectory, kore, project.libraries, project.targetOptions, secondPass);
 	}
 }
 


### PR DESCRIPTION
1) Added support for configuring "initial window size" via khafile.js (hxml + FD + html). It's just a replacement for the hardcoded exporter.setWidthAndHeight(800, 600) in main.js.

2) Added support for configuring swf version, framerate and stage background for Flash (hxml + FD files) via khafile.js.

sample khafile.js:
var project = new Project(...);
project.windowOptions.width = 1366;
project.windowOptions.height = 768;
project.targetOptions.flash.swfVersion = 11.6;
project.targetOptions.flash.framerate = 42;
project.targetOptions.flash.stageBackground = 'ff0000';
...

This should fix #21 and https://github.com/KTXSoftware/Kha/issues/201 if one wants a fixed size canvas. 