### PR TITLE
Haxelib deps with periods should get turned into commas

### DIFF
--- a/Project.js
+++ b/Project.js
@@ -151,7 +151,7 @@ class Project {
 			// looking in the haxelib folders.
 			// e.g. addLibrary('hxcpp') => '/usr/lib/haxelib/hxcpp/3,2,193'
             try {
-                libpath = path.join(child_process.execSync('haxelib config', { encoding: 'utf8' }).trim(), name.toLowerCase());
+                libpath = path.join(child_process.execSync('haxelib config', { encoding: 'utf8' }).trim(), name.replaceAll('.', ',').toLowerCase());
             }
             catch (error) {
                 libpath = path.join(process.env.HAXEPATH, 'lib', name.toLowerCase());


### PR DESCRIPTION
An example is thx.core. When installed its thx,core instead.