### PR TITLE
Write libroot into korefile

### DIFF
--- a/Project.js
+++ b/Project.js
@@ -147,7 +147,7 @@ class Project {
 			// e.g. 'Libraries/wyngine'
 			let libpath = path.join(self.scriptdir, 'Libraries', name);
 			if (fs.existsSync(libpath) && fs.statSync(libpath).isDirectory()) {
-				return { libpath: libpath, libroot: '' };
+				return { libpath: libpath, libroot: 'Libraries/' + name };
 			}
 			// If the library couldn't be found in Libraries folder, try
 			// looking in the haxelib folders.

--- a/main.js
+++ b/main.js
@@ -285,7 +285,7 @@ function exportProjectFiles(name, from, to, options, exporter, platform, khaDire
 			out += "}\n";*/
 
 			for (let lib of libraries) {
-				var libPath = lib.libpath;
+				var libPath = lib.libroot;
 				out += "if (fs.existsSync(path.join('" + libPath.replaceAll('\\', '/') + "', 'korefile.js'))) {\n";
 				out += "\tproject.addSubProject(Solution.createProject('" + libPath.replaceAll('\\', '/') + "'));\n";
 				out += "}\n";


### PR DESCRIPTION
This fixes issues with adding cpp sources in korefiles.

However I am not sure why there was libpath used(which can point to haxe sources of library), maybe this breaks some other thing? Also libroot was empty for some reason.

The whole haxelib thing adds so much complexity to this, guess there is no way around it. There are also dead/commented lines around, we need to clean it up a little before it turns into monster:)