### PR TITLE
Find directly referenced assets faster.

### DIFF
--- a/Project.js
+++ b/Project.js
@@ -17,13 +17,17 @@ function findFiles(dir, match) {
 	if (match.indexOf('*') >= 0) {
 		let beforeStar = match.substring(0, match.indexOf('*'));
 		subdir = beforeStar.substring(0, beforeStar.lastIndexOf('/'));
-	}
-		
-	let regex = new RegExp('^' + match.replace(/\./g, "\\.").replace(/\*\*/g, ".?").replace(/\*/g, "[^/]*").replace(/\?/g, '*') + '$', 'g');
+        
+        let regex = new RegExp('^' + match.replace(/\./g, "\\.").replace(/\*\*/g, ".?").replace(/\*/g, "[^/]*").replace(/\?/g, '*') + '$', 'g');
 	
-	let collected = [];
-	findFiles2(dir, subdir, regex, collected);
-	return collected;
+        let collected = [];
+        findFiles2(dir, subdir, regex, collected);
+        return collected;
+	}
+    else {
+        let file = path.resolve(dir, match);
+        return [file];
+    }
 }
 
 function findFiles2(basedir, dir, regex, collected) {


### PR DESCRIPTION
Attempt to solve slowness of khamake when including assets/shaders directly by name. Is RegExp currently needed when there are no * characters?

This change speeds up my repeated html5 build process by at least 10 seconds, down to about 3-4 now. Probably still room for improvement - debugging khamake easily with VS Code is a huge plus.