### PR TITLE
ignore '-lib xxx' in extraParams.hxml 

### DIFF
--- a/Project.js
+++ b/Project.js
@@ -224,7 +224,14 @@ class Project {
 				for (let parameter of params.split('\n')) {
 					let param = parameter.trim();
 					if (param !== '') {
-						this.addParameter(param);
+                        if (param.startsWith('-lib')) {
+                            // (DK)
+                            //  - '-lib xxx' is for linking a library via haxe, it forces the use of the haxelib version
+                            //  - this should be handled by khamake though, as it tracks the dependencies better (local folder or haxelib)
+                            console.log('ignoring', dir + '/extraParams.hxml "' + param + '"');
+                        } else {
+                            this.addParameter(param);
+                        }
 					}
 				}
 			}


### PR DESCRIPTION
Using ```-lib xxx``` in extraParams.hxml file causes haxe to link to and force the haxelib version of that library. The problem is, haxe doesn't know about a potential one in /Libraries. The library in question would already be added by khamake via the haxelib.json dependencies field (or manually in khafile.js) anyway.
