### PR TITLE
Don't crash when result.std{err,out} are null.

### DIFF
--- a/Haxe.js
+++ b/Haxe.js
@@ -20,13 +20,17 @@ exports.executeHaxe = function (from, haxeDirectory, options) {
 	}
 	let result = child_process.spawnSync(exe, options, { env: env, cwd: path.normalize(from.toString()) });
 
-	if (result.stdout.toString() !== '') {
+	if (result.stdout && result.stdout.toString() !== '') {
 		log.info(result.stdout.toString());
 	}
 
-	if (result.stderr.toString() !== '') {
+	if (result.stderr && result.stderr.toString() !== '') {
 		log.error(result.stderr.toString());
 	}
 	
+	if (result.error) {
+		log.error('Haxe.js ' + from + ' error (' + options + '): ' + result.error);
+	}
+
 	return result.status;
 };

--- a/main.js
+++ b/main.js
@@ -47,11 +47,11 @@ function compileShader2(compiler, type, from, to, temp, system) {
 	if (compiler !== '') {
 		let result = child_process.spawnSync(compiler, [type, from.toString(), to.toString(), temp.toString(), system]);
 
-		if (result.stdout.toString() !== '') {
+		if (result.stdout && result.stdout.toString() !== '') {
 			log.info(result.stdout.toString());
 		}
 
-		if (result.stderr.toString() !== '') {
+		if (result.stderr && result.stderr.toString() !== '') {
 			log.info(result.stderr.toString());
 		}
 


### PR DESCRIPTION
I ran into this issue on Linux (NodeJS v4.4.3) while it worked fine for me on Windows (NodeJS v4.4.5).

[... time passes ...]

Now that I've got everything working, let me be more clear: I had checked out Kha the night before on Windows and everything ran fine (using Git Bash shell).  The next morning on my Linux machine I ran into some issues because the Windows checkout hadn't made several needed binaries executable.  Therefore khamake crashed for unclear reasons.

After fixing the crashes on the nulls it became clear to me that some binaries needed to be executable. So this commit may still be useful for rare cases like mine described above.