### PR TITLE
changed the exported project filename

### DIFF
--- a/AndroidExporter.js
+++ b/AndroidExporter.js
@@ -60,7 +60,7 @@ class AndroidExporter extends KhaExporter {
 
 		this.exportAndroidStudioProject(name, _targetOptions, from);
 
-		return Haxe.executeHaxe(this.directory, haxeDirectory, ['project-' + this.sysdir() + '.hxml']);
+		return Haxe.executeHaxe(this.directory, haxeDirectory, [name + '-project-' + this.sysdir() + '.hxml']);
 	}
 
 	exportAndroidStudioProject(name, _targetOptions, from) {

--- a/CSharpExporter.js
+++ b/CSharpExporter.js
@@ -58,7 +58,7 @@ class CSharpExporter extends KhaExporter {
 
 		Files.removeDirectory(this.directory.resolve(Paths.get(this.sysdir() + "-build", "Sources")));
 
-		let result = Haxe.executeHaxe(this.directory, haxeDirectory, ['project-' + this.sysdir() + '.hxml']);
+		let result = Haxe.executeHaxe(this.directory, haxeDirectory, [name + '-project-' + this.sysdir() + '.hxml']);
 		const projectUuid = uuid.v4();
 		this.exportSLN(projectUuid);
 		this.exportCsProj(projectUuid);

--- a/Data/intellij/name.iml
+++ b/Data/intellij/name.iml
@@ -6,7 +6,7 @@
     <option name="excludeFromCompilation" value="true" />
     <option name="flexSdkName" value="flex_sdk_4.6" />
     <option name="haxeTarget" value="{target}" />
-    <option name="hxmlPath" value="$MODULE_DIR$/../project-{system}.hxml" />
+    <option name="hxmlPath" value="$MODULE_DIR$/../{name}-project-{system}.hxml" />
     <option name="mainClass" value="Main" />
     <option name="outputFileName" value="kha.swf" />
     <option name="outputFolder" value="$MODULE_DIR$/../{system}" />

--- a/EmptyExporter.js
+++ b/EmptyExporter.js
@@ -50,7 +50,7 @@ class EmptyExporter extends KhaExporter {
 		HaxeProject(this.directory.toString(), options);
 
 		if (Options.compilation) {
-			let result = Haxe.executeHaxe(this.directory, haxeDirectory, ['project-' + this.sysdir() + '.hxml']);
+			let result = Haxe.executeHaxe(this.directory, haxeDirectory, [name + '-project-' + this.sysdir() + '.hxml']);
 			if (result === 0) {
 				let doxresult = child_process.spawnSync('haxelib', ['run', 'dox', '-in', 'kha.*', '-i', path.join('build', options.to)], { env: process.env, cwd: path.normalize(from.toString()) });
 				if (doxresult.stdout.toString() !== '') {

--- a/FlashExporter.js
+++ b/FlashExporter.js
@@ -109,7 +109,7 @@ class FlashExporter extends KhaExporter {
 		}
 
 		if (Options.compilation) {
-			return Haxe.executeHaxe(this.directory, haxeDirectory, ['project-' + this.sysdir() + '.hxml']);
+			return Haxe.executeHaxe(this.directory, haxeDirectory, [name + '-project-' + this.sysdir() + '.hxml']);
 		}
 		else {
 			return 0;

--- a/HaxeProject.js
+++ b/HaxeProject.js
@@ -15,7 +15,7 @@ function copyAndReplace(from, to, names, values) {
 
 function IntelliJ(projectdir, options) {
     let indir = path.join(__dirname, 'Data', 'intellij');
-    let outdir = path.join(projectdir, 'project-' + options.system + '-intellij');
+    let outdir = path.join(projectdir, options.name + '-project-' + options.system + '-intellij');
 
 	let sources = '';
 	for (let i = 0; i < options.sources.length; ++i) {
@@ -145,7 +145,7 @@ function hxml(projectdir, options) {
 		data += param + '\n';
 	}
 	data += '-main Main' + '\n';
-	fs.outputFileSync(path.join(projectdir, 'project-' + options.system + '.hxml'), data);
+	fs.outputFileSync(path.join(projectdir, options.name + '-project-' + options.system + '.hxml'), data);
 }
 
 function FlashDevelop(projectdir, options) {
@@ -407,7 +407,7 @@ function FlashDevelop(projectdir, options) {
 		]
 	};
 
-	XmlWriter(project, path.join(projectdir, 'project-' + options.system + '.hxproj'));
+	XmlWriter(project, path.join(projectdir, options.name + '-project-' + options.system + '.hxproj'));
 }
 
 module.exports = function (projectdir, options) {

--- a/Html5Exporter.js
+++ b/Html5Exporter.js
@@ -95,7 +95,7 @@ class Html5Exporter extends KhaExporter {
 		}
 		
 		if (Options.compilation) {
-			return Haxe.executeHaxe(this.directory, haxeDirectory, ['project-' + this.sysdir() + '.hxml']);
+			return Haxe.executeHaxe(this.directory, haxeDirectory, [name + '-project-' + this.sysdir() + '.hxml']);
 		}
 		else {
 			return 0;

--- a/JavaExporter.js
+++ b/JavaExporter.js
@@ -50,7 +50,7 @@ class JavaExporter extends KhaExporter {
 
 		Files.removeDirectory(this.directory.resolve(Paths.get(this.sysdir(), "Sources")));
 
-		let result = Haxe.executeHaxe(this.directory, haxeDirectory, ['project-' + this.sysdir() + '.hxml']);
+		let result = Haxe.executeHaxe(this.directory, haxeDirectory, [name + '-project-' + this.sysdir() + '.hxml']);
 		this.exportEclipseProject();
 		return result;
 	}

--- a/KoreExporter.js
+++ b/KoreExporter.js
@@ -62,7 +62,7 @@ class KoreExporter extends KhaExporter {
 
 		//Files.removeDirectory(this.directory.resolve(Paths.get(this.sysdir() + "-build", "Sources")));
 
-		return Haxe.executeHaxe(this.directory, haxeDirectory, ["project-" + this.sysdir() + ".hxml"]);
+		return Haxe.executeHaxe(this.directory, haxeDirectory, [name + '-project-' + this.sysdir() + ".hxml"]);
 	}
 
 	/*copyMusic(platform, from, to, encoders, callback) {

--- a/KoreHLExporter.js
+++ b/KoreHLExporter.js
@@ -62,7 +62,7 @@ class KoreHLExporter extends KhaExporter {
 
 		//Files.removeDirectory(this.directory.resolve(Paths.get(this.sysdir() + "-build", "Sources")));
 
-		return Haxe.executeHaxe(this.directory, haxeDirectory, ["project-" + this.sysdir() + ".hxml"]);
+		return Haxe.executeHaxe(this.directory, haxeDirectory, [name + '-project-' + this.sysdir() + ".hxml"]);
 	}
 
 	/*copyMusic(platform, from, to, encoders, callback) {

--- a/UnityExporter.js
+++ b/UnityExporter.js
@@ -52,7 +52,7 @@ class UnityExporter extends KhaExporter {
 
 		Files.removeDirectory(this.directory.resolve(Paths.get(this.sysdir(), "Assets", "Sources")));
 
-		let result = Haxe.executeHaxe(this.directory, haxeDirectory, ['project-' + this.sysdir() + '.hxml']);
+		let result = Haxe.executeHaxe(this.directory, haxeDirectory, [name + '-project-' + this.sysdir() + '.hxml']);
 		var copyDirectory = (from, to) => {
 			let files = fs.readdirSync(path.join(__dirname, 'Data', 'unity', from));
 			this.createDirectory(this.directory.resolve(Paths.get(this.sysdir(), to)));


### PR DESCRIPTION
![fd-recent-projects-menu](https://cloud.githubusercontent.com/assets/13007175/16453976/0fb9fd7c-3e0f-11e6-89b4-c4445ea644db.jpg)
![fd-recent-projects-toolbar](https://cloud.githubusercontent.com/assets/13007175/16453975/0fb9246a-3e0f-11e6-85c8-231bb0433661.jpg)

When using multiple projects in FlashDevelop it's quite annoying to only ever see ```some-truncated-directory/project-flash.hxproj``` in the 'Recent Projects' list and having to hover over it to see the path; and even more annoying with the 'Recent Projects' toolbar button as it only shows the project name without a directory.

This PR changes the generated filename from ```project-${sys}.hxproj``` to ```${projectname}-project-${sys}.hxproj```

Edit: ${projectname} is whatever you name your project in the khafile.js
Edit2: It also changes the generated *.hxml filename *-intellij folder
