### PR TITLE
 assets in subfolders

### DIFF
--- a/AssetConverter.ts
+++ b/AssetConverter.ts
@@ -21,8 +21,18 @@ export class AssetConverter {
 		if (options.name) {
 			let name: string = options.name;
 			let basePath: string = options.nameBaseDir ? path.join(from, options.nameBaseDir) : from;
-			console.log(basePath, path.relative(basePath, fileinfo.dir)); 
-			return name.replace(/{name}/g, fileinfo.name).replace(/{ext}/g, fileinfo.ext).replace(/{dir}/g, path.relative(basePath, fileinfo.dir));
+			let dirValue: string = path.relative(basePath, fileinfo.dir);
+            if (basePath.length > 0 
+                && basePath[basePath.length - 1] == path.sep 
+                && dirValue.length > 0
+                && dirValue[dirValue.length - 1] != path.sep) 
+                    dirValue += path.sep;
+            if (options.namePathSeparator)
+                dirValue = dirValue.split(path.sep).join(options.namePathSeparator);
+			let nameValue = fileinfo.name;
+			if(keepextension && name.indexOf("{ext}") < 0)
+				nameValue += fileinfo.ext;
+			return name.replace(/{name}/g, nameValue).replace(/{ext}/g, fileinfo.ext).replace(/{dir}/g, dirValue);
 		}
 		else if (keepextension) return fileinfo.name + '.' + fileinfo.ext;
 		else return fileinfo.name;
@@ -63,30 +73,39 @@ export class AssetConverter {
 						case '.png':
 						case '.jpg':
 						case '.jpeg':
-						case '.hdr':
-							let name = fixName(this.createName(fileinfo, false, options, this.exporter.options.from));
+						case '.hdr': {
+							let name = this.createName(fileinfo, false, options, this.exporter.options.from);
 							let images = await this.exporter.copyImage(this.platform, file, name, options);
 							parsedFiles.push({ name: name, from: file, type: 'image', files: images });
 							break;
-						case '.wav':
-							let sounds = await this.exporter.copySound(this.platform, file, fileinfo.name);
-							parsedFiles.push({ name: this.createName(fileinfo, false, options, this.exporter.options.from), from: file, type: 'sound', files: sounds });
+						}
+						case '.wav': {
+							let name = this.createName(fileinfo, false, options, this.exporter.options.from);
+							let sounds = await this.exporter.copySound(this.platform, file, name);
+							parsedFiles.push({ name: name, from: file, type: 'sound', files: sounds });
 							break;
-						case '.ttf':
-							let fonts = await this.exporter.copyFont(this.platform, file, fileinfo.name);
-							parsedFiles.push({ name: this.createName(fileinfo, false, options, this.exporter.options.from), from: file, type: 'font', files: fonts });
+						}
+						case '.ttf': {
+							let name = this.createName(fileinfo, false, options, this.exporter.options.from);
+							let fonts = await this.exporter.copyFont(this.platform, file, name);
+							parsedFiles.push({ name: name, from: file, type: 'font', files: fonts });
 							break;
+						}
 						case '.mp4':
 						case '.webm':
 						case '.wmv':
-						case '.avi':
-							let videos = await this.exporter.copyVideo(this.platform, file, fileinfo.name);
-							parsedFiles.push({ name: this.createName(fileinfo, false, options, this.exporter.options.from), from: file, type: 'video', files: videos });
+						case '.avi': {
+							let name = this.createName(fileinfo, false, options, this.exporter.options.from);
+							let videos = await this.exporter.copyVideo(this.platform, file, name);
+							parsedFiles.push({ name: name, from: file, type: 'video', files: videos });
 							break;
-						default:
-							let blobs = await this.exporter.copyBlob(this.platform, file, fileinfo.name);
-							parsedFiles.push({ name: this.createName(fileinfo, true, options, this.exporter.options.from), from: file, type: 'blob', files: blobs });
+						}
+						default: {
+							let name = this.createName(fileinfo, true, options, this.exporter.options.from);
+							let blobs = await this.exporter.copyBlob(this.platform, file, name);
+							parsedFiles.push({ name: name, from: file, type: 'blob', files: blobs });
 							break;
+						}
 					}
 					++index;
 				}

--- a/AssetConverter.ts
+++ b/AssetConverter.ts
@@ -20,7 +20,9 @@ export class AssetConverter {
 	createName(fileinfo: path.ParsedPath, keepextension: boolean, options: any, from: string): string {
 		if (options.name) {
 			let name: string = options.name;
-			return name.replace(/{name}/g, fileinfo.name).replace(/{ext}/g, fileinfo.ext).replace(/{dir}/g, path.relative(from, fileinfo.dir));
+			let basePath: string = options.nameBaseDir ? path.join(from, options.nameBaseDir) : from;
+			console.log(basePath, path.relative(basePath, fileinfo.dir)); 
+			return name.replace(/{name}/g, fileinfo.name).replace(/{ext}/g, fileinfo.ext).replace(/{dir}/g, path.relative(basePath, fileinfo.dir));
 		}
 		else if (keepextension) return fileinfo.name + '.' + fileinfo.ext;
 		else return fileinfo.name;

--- a/AssetConverter.ts
+++ b/AssetConverter.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import {KhaExporter} from './Exporters/KhaExporter';
 import * as log from './log';
 import * as chokidar from 'chokidar';
+import {fixName} from "./main"
 
 export class AssetConverter {
 	exporter: KhaExporter;
@@ -61,8 +62,9 @@ export class AssetConverter {
 						case '.jpg':
 						case '.jpeg':
 						case '.hdr':
-							let images = await this.exporter.copyImage(this.platform, file, fileinfo.name, options);
-							parsedFiles.push({ name: this.createName(fileinfo, false, options, this.exporter.options.from), from: file, type: 'image', files: images });
+							let name = fixName(this.createName(fileinfo, false, options, this.exporter.options.from));
+							let images = await this.exporter.copyImage(this.platform, file, name, options);
+							parsedFiles.push({ name: name, from: file, type: 'image', files: images });
 							break;
 						case '.wav':
 							let sounds = await this.exporter.copySound(this.platform, file, fileinfo.name);
@@ -91,8 +93,8 @@ export class AssetConverter {
 		});
 	}
 	
-	async run(watch: boolean): Promise<{ from: string, type: string, files: string[] }[]> {
-		let files: { from: string, type: string, files: string[] }[] = [];
+	async run(watch: boolean): Promise<{ name: string, from: string, type: string, files: string[] }[]> {
+		let files: { name: string, from: string, type: string, files: string[] }[] = [];
 		for (let matcher of this.assetMatchers) {
 			files = files.concat(await this.watch(watch, matcher.match, matcher.options));
 		}

--- a/main.ts
+++ b/main.ts
@@ -58,8 +58,8 @@ function addShader(project, name, extension) {
 	project.exportedShaders.push({files: [name + extension], name: name});
 }
 
-function fixName(name) {
-	name = name.replace(/\./g, '_').replace(/-/g, '_');
+export function fixName(name) {
+	name = name.replace(/[-./\\]/g, '_');
 	if (name[0] === '0' || name[0] === '1' || name[0] === '2' || name[0] === '3' || name[0] === '4'
 		|| name[0] === '5' || name[0] === '6' || name[0] === '7' || name[0] === '8' || name[0] === '9') {
 		name = '_' + name;
@@ -387,7 +387,7 @@ async function exportKhaProject(options: Options): Promise<string> {
 	let files = [];
 	for (let asset of assets) {
 		files.push({
-			name: fixName(path.parse(asset.from).name),
+			name: fixName(asset.name),
 			files: asset.files,
 			type: asset.type
 		});

--- a/out/AssetConverter.js
+++ b/out/AssetConverter.js
@@ -10,7 +10,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 const path = require('path');
 const log = require('./log');
 const chokidar = require('chokidar');
-const main_1 = require("./main");
 class AssetConverter {
     constructor(exporter, platform, assetMatchers) {
         this.exporter = exporter;
@@ -22,9 +21,17 @@ class AssetConverter {
             let name = options.name;
             let basePath = options.nameBaseDir ? path.join(from, options.nameBaseDir) : from;
             let dirValue = path.relative(basePath, fileinfo.dir);
-            if (dirValue.length > 0)
-                 dirValue += '_';
-            return name.replace(/{name}/g, fileinfo.name).replace(/{ext}/g, fileinfo.ext).replace(/{dir}/g, dirValue);
+            if (basePath.length > 0
+                && basePath[basePath.length - 1] == path.sep
+                && dirValue.length > 0
+                && dirValue[dirValue.length - 1] != path.sep)
+                dirValue += path.sep;
+            if (options.namePathSeparator)
+                dirValue = dirValue.split(path.sep).join(options.namePathSeparator);
+            let nameValue = fileinfo.name;
+            if (keepextension && name.indexOf("{ext}") < 0)
+                nameValue += fileinfo.ext;
+            return name.replace(/{name}/g, nameValue).replace(/{ext}/g, fileinfo.ext).replace(/{dir}/g, dirValue);
         }
         else if (keepextension)
             return fileinfo.name + '.' + fileinfo.ext;
@@ -64,30 +71,39 @@ class AssetConverter {
                         case '.png':
                         case '.jpg':
                         case '.jpeg':
-                        case '.hdr':
-                            let name = main_1.fixName(this.createName(fileinfo, false, options, this.exporter.options.from));
+                        case '.hdr': {
+                            let name = this.createName(fileinfo, false, options, this.exporter.options.from);
                             let images = yield this.exporter.copyImage(this.platform, file, name, options);
                             parsedFiles.push({ name: name, from: file, type: 'image', files: images });
                             break;
-                        case '.wav':
-                            let sounds = yield this.exporter.copySound(this.platform, file, fileinfo.name);
-                            parsedFiles.push({ name: this.createName(fileinfo, false, options, this.exporter.options.from), from: file, type: 'sound', files: sounds });
+                        }
+                        case '.wav': {
+                            let name = this.createName(fileinfo, false, options, this.exporter.options.from);
+                            let sounds = yield this.exporter.copySound(this.platform, file, name);
+                            parsedFiles.push({ name: name, from: file, type: 'sound', files: sounds });
                             break;
-                        case '.ttf':
-                            let fonts = yield this.exporter.copyFont(this.platform, file, fileinfo.name);
-                            parsedFiles.push({ name: this.createName(fileinfo, false, options, this.exporter.options.from), from: file, type: 'font', files: fonts });
+                        }
+                        case '.ttf': {
+                            let name = this.createName(fileinfo, false, options, this.exporter.options.from);
+                            let fonts = yield this.exporter.copyFont(this.platform, file, name);
+                            parsedFiles.push({ name: name, from: file, type: 'font', files: fonts });
                             break;
+                        }
                         case '.mp4':
                         case '.webm':
                         case '.wmv':
-                        case '.avi':
-                            let videos = yield this.exporter.copyVideo(this.platform, file, fileinfo.name);
-                            parsedFiles.push({ name: this.createName(fileinfo, false, options, this.exporter.options.from), from: file, type: 'video', files: videos });
+                        case '.avi': {
+                            let name = this.createName(fileinfo, false, options, this.exporter.options.from);
+                            let videos = yield this.exporter.copyVideo(this.platform, file, name);
+                            parsedFiles.push({ name: name, from: file, type: 'video', files: videos });
                             break;
-                        default:
-                            let blobs = yield this.exporter.copyBlob(this.platform, file, fileinfo.name);
-                            parsedFiles.push({ name: this.createName(fileinfo, true, options, this.exporter.options.from), from: file, type: 'blob', files: blobs });
+                        }
+                        default: {
+                            let name = this.createName(fileinfo, true, options, this.exporter.options.from);
+                            let blobs = yield this.exporter.copyBlob(this.platform, file, name);
+                            parsedFiles.push({ name: name, from: file, type: 'blob', files: blobs });
                             break;
+                        }
                     }
                     ++index;
                 }

--- a/out/AssetConverter.js
+++ b/out/AssetConverter.js
@@ -20,7 +20,11 @@ class AssetConverter {
     createName(fileinfo, keepextension, options, from) {
         if (options.name) {
             let name = options.name;
-            return name.replace(/{name}/g, fileinfo.name).replace(/{ext}/g, fileinfo.ext).replace(/{dir}/g, path.relative(from, fileinfo.dir));
+            let basePath = options.nameBaseDir ? path.join(from, options.nameBaseDir) : from;
+            let dirValue = path.relative(basePath, fileinfo.dir);
+            if (dirValue.length > 0)
+                 dirValue += '_';
+            return name.replace(/{name}/g, fileinfo.name).replace(/{ext}/g, fileinfo.ext).replace(/{dir}/g, dirValue);
         }
         else if (keepextension)
             return fileinfo.name + '.' + fileinfo.ext;

--- a/out/AssetConverter.js
+++ b/out/AssetConverter.js
@@ -10,6 +10,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 const path = require('path');
 const log = require('./log');
 const chokidar = require('chokidar');
+const main_1 = require("./main");
 class AssetConverter {
     constructor(exporter, platform, assetMatchers) {
         this.exporter = exporter;
@@ -60,8 +61,9 @@ class AssetConverter {
                         case '.jpg':
                         case '.jpeg':
                         case '.hdr':
-                            let images = yield this.exporter.copyImage(this.platform, file, fileinfo.name, options);
-                            parsedFiles.push({ name: this.createName(fileinfo, false, options, this.exporter.options.from), from: file, type: 'image', files: images });
+                            let name = main_1.fixName(this.createName(fileinfo, false, options, this.exporter.options.from));
+                            let images = yield this.exporter.copyImage(this.platform, file, name, options);
+                            parsedFiles.push({ name: name, from: file, type: 'image', files: images });
                             break;
                         case '.wav':
                             let sounds = yield this.exporter.copySound(this.platform, file, fileinfo.name);

--- a/out/main.js
+++ b/out/main.js
@@ -56,13 +56,14 @@ function addShader(project, name, extension) {
     project.exportedShaders.push({ files: [name + extension], name: name });
 }
 function fixName(name) {
-    name = name.replace(/\./g, '_').replace(/-/g, '_');
+    name = name.replace(/[-./\\]/g, '_');
     if (name[0] === '0' || name[0] === '1' || name[0] === '2' || name[0] === '3' || name[0] === '4'
         || name[0] === '5' || name[0] === '6' || name[0] === '7' || name[0] === '8' || name[0] === '9') {
         name = '_' + name;
     }
     return name;
 }
+exports.fixName = fixName;
 function exportProjectFiles(name, options, exporter, kore, korehl, libraries, targetOptions, defines) {
     return __awaiter(this, void 0, Promise, function* () {
         if (options.haxe !== '') {
@@ -356,7 +357,7 @@ function exportKhaProject(options) {
         let files = [];
         for (let asset of assets) {
             files.push({
-                name: fixName(path.parse(asset.from).name),
+                name: fixName(asset.name),
                 files: asset.files,
                 type: asset.type
             });


### PR DESCRIPTION
Added supprot for assets in subdirectories. I see that there was some idea of how to do that, but work was not finished.
Usage:
```js
//khafile.js
project.addAssets('Assets/**', {name:"{dir}{name}", nameBaseDir:'Assets', namePathSeparator:'_slash_'});
```
nameBaseDir is relative to project folder and is optional, if not specified, it's just project folder.
namePathSeparator is optional. If not specified "_" will be used.
file 'Assets/subfolder/foo.png' will be accessible as Assets.images.subfolder_foo in haxe.


