### PR TITLE
Add define on add library

### DIFF
--- a/Project.ts
+++ b/Project.ts
@@ -89,6 +89,7 @@ export class Project {
 	}
 
 	addLibrary(library) {
+		this.addDefine(library);
 		let self = this;
 		function findLibraryDirectory(name: string) {
 			// Tries to load the default library from inside the kha project.

--- a/out/Project.js
+++ b/out/Project.js
@@ -59,6 +59,7 @@ class Project {
         this.customTargets.set(name, new Target(baseTarget, backends));
     }
     addLibrary(library) {
+        this.addDefine(library);
         let self = this;
         function findLibraryDirectory(name) {
             // Tries to load the default library from inside the kha project.


### PR DESCRIPTION
Haxe automatically adds a define with the name of the library passed with -lib: http://old.haxe.org/doc/compiler#compilation-options
Khamake right know just adds the library via -cp so the define is lost.

The define is helpful to make some classes that use a certain lib available only when the lib is being used