### PR TITLE
--noproject Option to build only source files

### DIFF
--- a/Exporters/AndroidExporter.ts
+++ b/Exporters/AndroidExporter.ts
@@ -6,6 +6,7 @@ import {executeHaxe} from '../Haxe';
 import {Options} from '../Options';
 import {exportImage} from '../ImageTool';
 import {writeHaxeProject} from '../HaxeProject';
+import {hxml} from '../HaxeProject';
 
 function findIcon(from: string, options: any) {
 	if (fs.existsSync(path.join(from, 'icon.png'))) return path.join(from, 'icon.png');
@@ -55,13 +56,13 @@ export class AndroidExporter extends KhaExporter {
 		};
 	}
 
-	async exportSolution(name: string, _targetOptions: any, defines: Array<string>): Promise<any> {
-		let haxeOptions = this.haxeOptions(name, _targetOptions, defines);
-		writeHaxeProject(this.options.to, haxeOptions);
+	async exportSolution(name: string, targetOptions: any, haxeOptions: any): Promise<void> {
+		hxml(this.options.to, haxeOptions);
 
-		this.exportAndroidStudioProject(name, _targetOptions, this.options.from);
-
-		return haxeOptions;
+		if (this.projectFiles) {
+			writeHaxeProject(this.options.to, haxeOptions);
+			this.exportAndroidStudioProject(name, targetOptions, this.options.from);
+		}
 	}
 
 	exportAndroidStudioProject(name: string, _targetOptions, from: string) {

--- a/Exporters/CSharpExporter.ts
+++ b/Exporters/CSharpExporter.ts
@@ -6,6 +6,7 @@ import {executeHaxe} from '../Haxe';
 import {Options} from '../Options';
 import {exportImage} from '../ImageTool';
 import {writeHaxeProject} from '../HaxeProject';
+import {hxml} from '../HaxeProject';
 const uuid = require('uuid');
 
 export abstract class CSharpExporter extends KhaExporter {
@@ -51,11 +52,14 @@ export abstract class CSharpExporter extends KhaExporter {
 		};
 	}
 
-	async exportSolution(name: string, _targetOptions: any, defines: Array<string>): Promise<any> {
+	async exportSolution(name: string, targetOptions: any, haxeOptions: any): Promise<void> {
 		this.addSourceDirectory(path.join(this.options.kha, 'Backends', this.backend()));
 		
-		let haxeOptions = this.haxeOptions(name, _targetOptions, defines);
-		writeHaxeProject(this.options.to, haxeOptions);
+		hxml(this.options.to, haxeOptions);
+
+		if (this.projectFiles) {
+			writeHaxeProject(this.options.to, haxeOptions);
+		}
 
 		fs.removeSync(path.join(this.options.to, this.sysdir() + '-build', 'Sources'));
 
@@ -63,8 +67,6 @@ export abstract class CSharpExporter extends KhaExporter {
 		this.exportSLN(projectUuid);
 		this.exportCsProj(projectUuid);
 		this.exportResources();
-
-		return haxeOptions;
 	}
 
 	exportSLN(projectUuid) {

--- a/Exporters/EmptyExporter.ts
+++ b/Exporters/EmptyExporter.ts
@@ -7,6 +7,7 @@ import {executeHaxe} from '../Haxe';
 import {Options} from '../Options';
 import {exportImage} from '../ImageTool';
 import {writeHaxeProject} from '../HaxeProject';
+import {hxml} from '../HaxeProject';
 import * as log from '../log';
 
 export class EmptyExporter extends KhaExporter {
@@ -45,11 +46,14 @@ export class EmptyExporter extends KhaExporter {
 		};
 	}
 
-	async exportSolution(name: string, _targetOptions: any, defines: Array<string>): Promise<any> {
+	async exportSolution(name: string, _targetOptions: any, haxeOptions: any): Promise<void> {
 		fs.ensureDirSync(path.join(this.options.to, this.sysdir()));
 
-		let haxeOptions = this.haxeOptions(name, _targetOptions, defines);
-		writeHaxeProject(this.options.to, haxeOptions);
+		hxml(this.options.to, haxeOptions);
+
+		if (this.projectFiles) {
+			writeHaxeProject(this.options.to, haxeOptions);
+		}
 
 		let result = await executeHaxe(this.options.to, this.options.haxe, ['project-' + this.sysdir() + '.hxml']);
 		if (result === 0) {
@@ -62,8 +66,6 @@ export class EmptyExporter extends KhaExporter {
 				log.error(doxresult.stderr.toString());
 			}
 		}
-
-		return haxeOptions;
 	}
 
 	async copySound(platform: string, from: string, to: string) {

--- a/Exporters/FlashExporter.ts
+++ b/Exporters/FlashExporter.ts
@@ -6,6 +6,7 @@ import {executeHaxe} from '../Haxe';
 import {Options} from '../Options';
 import {exportImage} from '../ImageTool';
 import {writeHaxeProject} from '../HaxeProject';
+import {hxml} from '../HaxeProject';
 
 function adjustFilename(filename: string): string {
 	filename = filename.replace(/\./g, '_');
@@ -71,9 +72,12 @@ export class FlashExporter extends KhaExporter {
 		};
 	}
 
-	async exportSolution(name: string, targetOptions: any, defines: Array<string>): Promise<any> {
-		let haxeOptions = this.haxeOptions(name, targetOptions, defines);
-		writeHaxeProject(this.options.to, haxeOptions);
+	async exportSolution(name: string, targetOptions: any, haxeOptions: any): Promise<void> {
+		hxml(this.options.to, haxeOptions);
+
+		if (this.projectFiles) {
+			writeHaxeProject(this.options.to, haxeOptions);
+		}
 
 		if (this.options.embedflashassets) {
 			this.writeFile(path.join(this.options.to, '..', 'Sources', 'Assets.hx'));
@@ -110,8 +114,6 @@ export class FlashExporter extends KhaExporter {
 
 			this.closeFile();
 		}
-
-		return haxeOptions;
 	}
 
 	async copySound(platform: string, from: string, to: string) {

--- a/Exporters/Html5Exporter.ts
+++ b/Exporters/Html5Exporter.ts
@@ -6,6 +6,7 @@ import {executeHaxe} from '../Haxe';
 import {Options} from '../Options';
 import {exportImage} from '../ImageTool';
 import {writeHaxeProject} from '../HaxeProject';
+import {hxml} from '../HaxeProject';
 
 export class Html5Exporter extends KhaExporter {
 	parameters: Array<string>;
@@ -73,11 +74,14 @@ export class Html5Exporter extends KhaExporter {
 		};
 	}
 
-	async exportSolution(name: string, _targetOptions: any, defines: Array<string>): Promise<any> {
+	async exportSolution(name: string, targetOptions: any, haxeOptions: any): Promise<void> {
 		fs.ensureDirSync(path.join(this.options.to, this.sysdir()));
 
-		let haxeOptions = this.haxeOptions(name, _targetOptions, defines);
-		writeHaxeProject(this.options.to, haxeOptions);
+		hxml(this.options.to, haxeOptions);
+
+		if (this.projectFiles) {
+			writeHaxeProject(this.options.to, haxeOptions);
+		}
 
 		if (this.isDebugHtml5()) {
 			let index = path.join(this.options.to, this.sysdir(), 'index.html');
@@ -119,8 +123,6 @@ export class Html5Exporter extends KhaExporter {
 				fs.writeFileSync(index.toString(), protoindex);
 			}
 		}
-		
-		return haxeOptions;
 	}
 
 	/*copyMusic(platform, from, to, encoders, callback) {

--- a/Exporters/JavaExporter.ts
+++ b/Exporters/JavaExporter.ts
@@ -6,6 +6,7 @@ import {executeHaxe} from '../Haxe';
 import {Options} from '../Options';
 import {exportImage} from '../ImageTool';
 import {writeHaxeProject} from '../HaxeProject';
+import {hxml} from '../HaxeProject';
 
 export class JavaExporter extends KhaExporter {
 	parameters: Array<string>;
@@ -41,19 +42,20 @@ export class JavaExporter extends KhaExporter {
 		};
 	}
 
-	async exportSolution(name: string, _targetOptions: any, defines: Array<string>): Promise<any> {
+	async exportSolution(name: string, targetOptions: any, haxeOptions: any): Promise<void> {
 		this.addSourceDirectory(path.join(this.options.kha, 'Backends', this.backend()));
 
 		fs.ensureDirSync(path.join(this.options.to, this.sysdir()));
 		
-		let haxeOptions = this.haxeOptions(name, _targetOptions, defines);
-		writeHaxeProject(this.options.to, haxeOptions);
+		hxml(this.options.to, haxeOptions);
+
+		if (this.projectFiles) {
+			writeHaxeProject(this.options.to, haxeOptions);
+		}
 
 		fs.removeSync(path.join(this.options.to, this.sysdir(), 'Sources'));
 
 		this.exportEclipseProject();
-
-		return haxeOptions;
 	}
 
 	backend() {

--- a/Exporters/KhaExporter.ts
+++ b/Exporters/KhaExporter.ts
@@ -11,6 +11,7 @@ export abstract class KhaExporter extends Exporter {
 	name: string;
 	safename: string;
 	options: Options;
+	projectFiles: boolean;
 	
 	constructor(options: Options) {
 		super();
@@ -20,11 +21,14 @@ export abstract class KhaExporter extends Exporter {
 		this.sources = [];
 		this.libraries = [];
 		this.addSourceDirectory(path.join(options.kha, 'Sources'));
+		this.projectFiles = !options.noproject;
 	}
 	
 	abstract sysdir(): string;
 
-	abstract async exportSolution(name: string, targetOptions: any, defines: Array<string>): Promise<any>;
+	abstract haxeOptions(name: string, targetOptions: any, defines: Array<string>): any;
+
+	abstract async exportSolution(name: string, targetOptions: any, haxeOptions: any): Promise<void>;
 
 	setWidthAndHeight(width: number, height: number): void {
 		this.width = width;

--- a/Exporters/KoreExporter.ts
+++ b/Exporters/KoreExporter.ts
@@ -6,6 +6,7 @@ import {executeHaxe} from '../Haxe';
 import {Platform} from '../Platform';
 import {exportImage} from '../ImageTool';
 import {writeHaxeProject} from '../HaxeProject';
+import {hxml} from '../HaxeProject';
 import {Options} from '../Options';
 
 export class KoreExporter extends KhaExporter {
@@ -58,13 +59,13 @@ export class KoreExporter extends KhaExporter {
 		};
 	}
 
-	async exportSolution(name: string, _targetOptions: any, defines: Array<string>): Promise<any> {
-		let haxeOptions = this.haxeOptions(name, _targetOptions, defines);
-		writeHaxeProject(this.options.to, haxeOptions);
+	async exportSolution(name: string, targetOptions: any, haxeOptions: any): Promise<void> {
+		hxml(this.options.to, haxeOptions);
 
+		if (this.projectFiles) {
+			writeHaxeProject(this.options.to, haxeOptions);
+		}
 		//Files.removeDirectory(this.directory.resolve(Paths.get(this.sysdir() + "-build", "Sources")));
-
-		return haxeOptions;
 	}
 
 	/*copyMusic(platform, from, to, encoders, callback) {

--- a/Exporters/KoreHLExporter.ts
+++ b/Exporters/KoreHLExporter.ts
@@ -6,6 +6,7 @@ import {executeHaxe} from '../Haxe';
 import {Platform} from '../Platform';
 import {exportImage} from '../ImageTool';
 import {writeHaxeProject} from '../HaxeProject';
+import {hxml} from '../HaxeProject';
 import {Options} from '../Options';
 
 export class KoreHLExporter extends KhaExporter {
@@ -56,13 +57,14 @@ export class KoreHLExporter extends KhaExporter {
 		};
 	}
 
-	async exportSolution(name: string, _targetOptions: any, defines: Array<string>): Promise<any> {
-		let haxeOptions = this.haxeOptions(name, _targetOptions, defines);
-		writeHaxeProject(this.options.to, haxeOptions);
+	async exportSolution(name: string, targetOptions: any, haxeOptions: any): Promise<void> {
+		hxml(this.options.to, haxeOptions);
+
+		if (this.projectFiles) {
+			writeHaxeProject(this.options.to, haxeOptions);
+		}
 
 		//Files.removeDirectory(this.directory.resolve(Paths.get(this.sysdir() + "-build", "Sources")));
-
-		return haxeOptions;
 	}
 
 	/*copyMusic(platform, from, to, encoders, callback) {

--- a/Exporters/KromExporter.ts
+++ b/Exporters/KromExporter.ts
@@ -6,6 +6,7 @@ import {executeHaxe} from '../Haxe';
 import {Options} from '../Options';
 import {exportImage} from '../ImageTool';
 import {writeHaxeProject} from '../HaxeProject';
+import {hxml} from '../HaxeProject';
 
 export class KromExporter extends KhaExporter {
 	parameters: Array<string>;
@@ -47,13 +48,14 @@ export class KromExporter extends KhaExporter {
 		};
 	}
 
-	async exportSolution(name: string, _targetOptions: any, defines: Array<string>): Promise<any> {
+	async exportSolution(name: string, targetOptions: any, haxeOptions: any): Promise<void> {
 		fs.ensureDirSync(path.join(this.options.to, this.sysdir()));
 
-		let haxeOptions = this.haxeOptions(name, defines);
-		writeHaxeProject(this.options.to, haxeOptions);
-		
-		return haxeOptions;
+		hxml(this.options.to, haxeOptions);
+
+		if (this.projectFiles) {
+			writeHaxeProject(this.options.to, haxeOptions);
+		}
 	}
 
 	async copySound(platform: string, from: string, to: string) {

--- a/HaxeProject.ts
+++ b/HaxeProject.ts
@@ -89,7 +89,7 @@ function IntelliJ(projectdir, options) {
 	fs.copySync(path.join(indir, 'idea', 'copyright', 'profiles_settings.xml'), path.join(outdir, '.idea', 'copyright', 'profiles_settings.xml'), { clobber: true });
 }
 
-function hxml(projectdir, options) {
+export function hxml(projectdir, options) {
 	let data = '';
 	for (let i = 0; i < options.sources.length; ++i) {
 		if (path.isAbsolute(options.sources[i])) {
@@ -404,9 +404,6 @@ function FlashDevelop(projectdir, options) {
 }
 
 export function writeHaxeProject(projectdir, options) {
-	options.defines.push('kha');
-	options.defines.push('kha_version=1607');
 	FlashDevelop(projectdir, options);
 	IntelliJ(projectdir, options);
-	hxml(projectdir, options);
 }

--- a/Options.ts
+++ b/Options.ts
@@ -30,6 +30,8 @@ export class Options {
 	haxe: string;
 	ffmpeg: string;
 	krafix: string;
+	
+	noproject: boolean;
 	embedflashassets: boolean;
 	compile: boolean;
 	run: boolean;

--- a/khamake.ts
+++ b/khamake.ts
@@ -111,6 +111,11 @@ var options: Array<any> = [
 		default: ''
 	},
 	{
+		full: 'noproject',
+		description: 'Only source files. Don\'t generate project files.',
+		value: false,
+	},
+	{
 		full: 'embedflashassets',
 		description: 'Embed assets in swf for flash target',
 		value: false

--- a/main.ts
+++ b/main.ts
@@ -44,11 +44,16 @@ function fixName(name: string): string {
 
 async function exportProjectFiles(name: string, options: Options, exporter: KhaExporter, kore: boolean, korehl: boolean, libraries, targetOptions, defines): Promise<string> {
 	if (options.haxe !== '') {
-		let haxeoptions = await exporter.exportSolution(name, targetOptions, defines);
-		let compiler = new HaxeCompiler(options.to, haxeoptions.to, haxeoptions.realto, options.haxe, 'project-' + exporter.sysdir() + '.hxml', ['Sources']);
+		let haxeOptions = exporter.haxeOptions(name, targetOptions, defines);
+		//haxeOptions.defines.push('kha');
+		//haxeOptions.defines.push('kha_version=1607');
+
+		await exporter.exportSolution(name, targetOptions, haxeOptions);
+
+		let compiler = new HaxeCompiler(options.to, haxeOptions.to, haxeOptions.realto, options.haxe, 'project-' + exporter.sysdir() + '.hxml', ['Sources']);
 		await compiler.run(options.watch);
 	}
-	if (options.haxe !== '' && kore) {
+	if (options.haxe !== '' && kore && !options.noproject) {
 		// If target is a Kore project, generate additional project folders here.
 		// generate the korefile.js
 		{
@@ -127,7 +132,7 @@ async function exportProjectFiles(name: string, options: Options, exporter: KhaE
 			return name;
 		}
 	}
-	else if (options.haxe !== '' && korehl) {
+	else if (options.haxe !== '' && korehl && !options.noproject) {
 		// If target is a Kore project, generate additional project folders here.
 		// generate the korefile.js
 		{

--- a/out/Exporters/AndroidExporter.js
+++ b/out/Exporters/AndroidExporter.js
@@ -12,6 +12,7 @@ const path = require('path');
 const KhaExporter_1 = require('./KhaExporter');
 const ImageTool_1 = require('../ImageTool');
 const HaxeProject_1 = require('../HaxeProject');
+const HaxeProject_2 = require('../HaxeProject');
 function findIcon(from, options) {
     if (fs.existsSync(path.join(from, 'icon.png')))
         return path.join(from, 'icon.png');
@@ -53,12 +54,13 @@ class AndroidExporter extends KhaExporter_1.KhaExporter {
             name: name
         };
     }
-    exportSolution(name, _targetOptions, defines) {
+    exportSolution(name, targetOptions, haxeOptions) {
         return __awaiter(this, void 0, Promise, function* () {
-            let haxeOptions = this.haxeOptions(name, _targetOptions, defines);
-            HaxeProject_1.writeHaxeProject(this.options.to, haxeOptions);
-            this.exportAndroidStudioProject(name, _targetOptions, this.options.from);
-            return haxeOptions;
+            HaxeProject_2.hxml(this.options.to, haxeOptions);
+            if (this.projectFiles) {
+                HaxeProject_1.writeHaxeProject(this.options.to, haxeOptions);
+                this.exportAndroidStudioProject(name, targetOptions, this.options.from);
+            }
         });
     }
     exportAndroidStudioProject(name, _targetOptions, from) {

--- a/out/Exporters/CSharpExporter.js
+++ b/out/Exporters/CSharpExporter.js
@@ -12,6 +12,7 @@ const path = require('path');
 const KhaExporter_1 = require('./KhaExporter');
 const ImageTool_1 = require('../ImageTool');
 const HaxeProject_1 = require('../HaxeProject');
+const HaxeProject_2 = require('../HaxeProject');
 const uuid = require('uuid');
 class CSharpExporter extends KhaExporter_1.KhaExporter {
     constructor(options) {
@@ -52,17 +53,18 @@ class CSharpExporter extends KhaExporter_1.KhaExporter {
             name: name
         };
     }
-    exportSolution(name, _targetOptions, defines) {
+    exportSolution(name, targetOptions, haxeOptions) {
         return __awaiter(this, void 0, Promise, function* () {
             this.addSourceDirectory(path.join(this.options.kha, 'Backends', this.backend()));
-            let haxeOptions = this.haxeOptions(name, _targetOptions, defines);
-            HaxeProject_1.writeHaxeProject(this.options.to, haxeOptions);
+            HaxeProject_2.hxml(this.options.to, haxeOptions);
+            if (this.projectFiles) {
+                HaxeProject_1.writeHaxeProject(this.options.to, haxeOptions);
+            }
             fs.removeSync(path.join(this.options.to, this.sysdir() + '-build', 'Sources'));
             const projectUuid = uuid.v4();
             this.exportSLN(projectUuid);
             this.exportCsProj(projectUuid);
             this.exportResources();
-            return haxeOptions;
         });
     }
     exportSLN(projectUuid) {

--- a/out/Exporters/EmptyExporter.js
+++ b/out/Exporters/EmptyExporter.js
@@ -13,6 +13,7 @@ const path = require('path');
 const KhaExporter_1 = require('./KhaExporter');
 const Haxe_1 = require('../Haxe');
 const HaxeProject_1 = require('../HaxeProject');
+const HaxeProject_2 = require('../HaxeProject');
 const log = require('../log');
 class EmptyExporter extends KhaExporter_1.KhaExporter {
     constructor(options) {
@@ -44,11 +45,13 @@ class EmptyExporter extends KhaExporter_1.KhaExporter {
             name: name
         };
     }
-    exportSolution(name, _targetOptions, defines) {
+    exportSolution(name, _targetOptions, haxeOptions) {
         return __awaiter(this, void 0, Promise, function* () {
             fs.ensureDirSync(path.join(this.options.to, this.sysdir()));
-            let haxeOptions = this.haxeOptions(name, _targetOptions, defines);
-            HaxeProject_1.writeHaxeProject(this.options.to, haxeOptions);
+            HaxeProject_2.hxml(this.options.to, haxeOptions);
+            if (this.projectFiles) {
+                HaxeProject_1.writeHaxeProject(this.options.to, haxeOptions);
+            }
             let result = yield Haxe_1.executeHaxe(this.options.to, this.options.haxe, ['project-' + this.sysdir() + '.hxml']);
             if (result === 0) {
                 let doxresult = child_process.spawnSync('haxelib', ['run', 'dox', '-in', 'kha.*', '-i', path.join('build', this.sysdir(), 'docs.xml')], { env: process.env, cwd: path.normalize(this.options.from) });
@@ -59,7 +62,6 @@ class EmptyExporter extends KhaExporter_1.KhaExporter {
                     log.error(doxresult.stderr.toString());
                 }
             }
-            return haxeOptions;
         });
     }
     copySound(platform, from, to) {

--- a/out/Exporters/FlashExporter.js
+++ b/out/Exporters/FlashExporter.js
@@ -13,6 +13,7 @@ const KhaExporter_1 = require('./KhaExporter');
 const Converter_1 = require('../Converter');
 const ImageTool_1 = require('../ImageTool');
 const HaxeProject_1 = require('../HaxeProject');
+const HaxeProject_2 = require('../HaxeProject');
 function adjustFilename(filename) {
     filename = filename.replace(/\./g, '_');
     filename = filename.replace(/-/g, '_');
@@ -65,10 +66,12 @@ class FlashExporter extends KhaExporter_1.KhaExporter {
             swfVersion: 'swfVersion' in flashOptions ? flashOptions.swfVersion : defaultFlashOptions.swfVersion
         };
     }
-    exportSolution(name, targetOptions, defines) {
+    exportSolution(name, targetOptions, haxeOptions) {
         return __awaiter(this, void 0, Promise, function* () {
-            let haxeOptions = this.haxeOptions(name, targetOptions, defines);
-            HaxeProject_1.writeHaxeProject(this.options.to, haxeOptions);
+            HaxeProject_2.hxml(this.options.to, haxeOptions);
+            if (this.projectFiles) {
+                HaxeProject_1.writeHaxeProject(this.options.to, haxeOptions);
+            }
             if (this.options.embedflashassets) {
                 this.writeFile(path.join(this.options.to, '..', 'Sources', 'Assets.hx'));
                 this.p("package;");
@@ -96,7 +99,6 @@ class FlashExporter extends KhaExporter_1.KhaExporter {
                 this.p("}");
                 this.closeFile();
             }
-            return haxeOptions;
         });
     }
     copySound(platform, from, to) {

--- a/out/Exporters/Html5Exporter.js
+++ b/out/Exporters/Html5Exporter.js
@@ -13,6 +13,7 @@ const KhaExporter_1 = require('./KhaExporter');
 const Converter_1 = require('../Converter');
 const ImageTool_1 = require('../ImageTool');
 const HaxeProject_1 = require('../HaxeProject');
+const HaxeProject_2 = require('../HaxeProject');
 class Html5Exporter extends KhaExporter_1.KhaExporter {
     constructor(options) {
         super(options);
@@ -65,11 +66,13 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
             name: name
         };
     }
-    exportSolution(name, _targetOptions, defines) {
+    exportSolution(name, targetOptions, haxeOptions) {
         return __awaiter(this, void 0, Promise, function* () {
             fs.ensureDirSync(path.join(this.options.to, this.sysdir()));
-            let haxeOptions = this.haxeOptions(name, _targetOptions, defines);
-            HaxeProject_1.writeHaxeProject(this.options.to, haxeOptions);
+            HaxeProject_2.hxml(this.options.to, haxeOptions);
+            if (this.projectFiles) {
+                HaxeProject_1.writeHaxeProject(this.options.to, haxeOptions);
+            }
             if (this.isDebugHtml5()) {
                 let index = path.join(this.options.to, this.sysdir(), 'index.html');
                 if (!fs.existsSync(index)) {
@@ -107,7 +110,6 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
                     fs.writeFileSync(index.toString(), protoindex);
                 }
             }
-            return haxeOptions;
         });
     }
     /*copyMusic(platform, from, to, encoders, callback) {

--- a/out/Exporters/JavaExporter.js
+++ b/out/Exporters/JavaExporter.js
@@ -12,6 +12,7 @@ const path = require('path');
 const KhaExporter_1 = require('./KhaExporter');
 const ImageTool_1 = require('../ImageTool');
 const HaxeProject_1 = require('../HaxeProject');
+const HaxeProject_2 = require('../HaxeProject');
 class JavaExporter extends KhaExporter_1.KhaExporter {
     constructor(options) {
         super(options);
@@ -40,15 +41,16 @@ class JavaExporter extends KhaExporter_1.KhaExporter {
             name: name
         };
     }
-    exportSolution(name, _targetOptions, defines) {
+    exportSolution(name, targetOptions, haxeOptions) {
         return __awaiter(this, void 0, Promise, function* () {
             this.addSourceDirectory(path.join(this.options.kha, 'Backends', this.backend()));
             fs.ensureDirSync(path.join(this.options.to, this.sysdir()));
-            let haxeOptions = this.haxeOptions(name, _targetOptions, defines);
-            HaxeProject_1.writeHaxeProject(this.options.to, haxeOptions);
+            HaxeProject_2.hxml(this.options.to, haxeOptions);
+            if (this.projectFiles) {
+                HaxeProject_1.writeHaxeProject(this.options.to, haxeOptions);
+            }
             fs.removeSync(path.join(this.options.to, this.sysdir(), 'Sources'));
             this.exportEclipseProject();
-            return haxeOptions;
         });
     }
     backend() {

--- a/out/Exporters/KhaExporter.js
+++ b/out/Exporters/KhaExporter.js
@@ -18,6 +18,7 @@ class KhaExporter extends Exporter_1.Exporter {
         this.sources = [];
         this.libraries = [];
         this.addSourceDirectory(path.join(options.kha, 'Sources'));
+        this.projectFiles = !options.noproject;
     }
     setWidthAndHeight(width, height) {
         this.width = width;

--- a/out/Exporters/KoreExporter.js
+++ b/out/Exporters/KoreExporter.js
@@ -14,6 +14,7 @@ const Converter_1 = require('../Converter');
 const Platform_1 = require('../Platform');
 const ImageTool_1 = require('../ImageTool');
 const HaxeProject_1 = require('../HaxeProject');
+const HaxeProject_2 = require('../HaxeProject');
 class KoreExporter extends KhaExporter_1.KhaExporter {
     constructor(options) {
         super(options);
@@ -59,12 +60,13 @@ class KoreExporter extends KhaExporter_1.KhaExporter {
             name: name
         };
     }
-    exportSolution(name, _targetOptions, defines) {
+    exportSolution(name, targetOptions, haxeOptions) {
         return __awaiter(this, void 0, Promise, function* () {
-            let haxeOptions = this.haxeOptions(name, _targetOptions, defines);
-            HaxeProject_1.writeHaxeProject(this.options.to, haxeOptions);
+            HaxeProject_2.hxml(this.options.to, haxeOptions);
+            if (this.projectFiles) {
+                HaxeProject_1.writeHaxeProject(this.options.to, haxeOptions);
+            }
             //Files.removeDirectory(this.directory.resolve(Paths.get(this.sysdir() + "-build", "Sources")));
-            return haxeOptions;
         });
     }
     /*copyMusic(platform, from, to, encoders, callback) {

--- a/out/Exporters/KoreHLExporter.js
+++ b/out/Exporters/KoreHLExporter.js
@@ -14,6 +14,7 @@ const Converter_1 = require('../Converter');
 const Platform_1 = require('../Platform');
 const ImageTool_1 = require('../ImageTool');
 const HaxeProject_1 = require('../HaxeProject');
+const HaxeProject_2 = require('../HaxeProject');
 class KoreHLExporter extends KhaExporter_1.KhaExporter {
     constructor(options) {
         super(options);
@@ -55,12 +56,13 @@ class KoreHLExporter extends KhaExporter_1.KhaExporter {
             name: name
         };
     }
-    exportSolution(name, _targetOptions, defines) {
+    exportSolution(name, targetOptions, haxeOptions) {
         return __awaiter(this, void 0, Promise, function* () {
-            let haxeOptions = this.haxeOptions(name, _targetOptions, defines);
-            HaxeProject_1.writeHaxeProject(this.options.to, haxeOptions);
+            HaxeProject_2.hxml(this.options.to, haxeOptions);
+            if (this.projectFiles) {
+                HaxeProject_1.writeHaxeProject(this.options.to, haxeOptions);
+            }
             //Files.removeDirectory(this.directory.resolve(Paths.get(this.sysdir() + "-build", "Sources")));
-            return haxeOptions;
         });
     }
     /*copyMusic(platform, from, to, encoders, callback) {

--- a/out/Exporters/KromExporter.js
+++ b/out/Exporters/KromExporter.js
@@ -13,6 +13,7 @@ const KhaExporter_1 = require('./KhaExporter');
 const Converter_1 = require('../Converter');
 const ImageTool_1 = require('../ImageTool');
 const HaxeProject_1 = require('../HaxeProject');
+const HaxeProject_2 = require('../HaxeProject');
 class KromExporter extends KhaExporter_1.KhaExporter {
     constructor(options) {
         super(options);
@@ -45,12 +46,13 @@ class KromExporter extends KhaExporter_1.KhaExporter {
             name: name
         };
     }
-    exportSolution(name, _targetOptions, defines) {
+    exportSolution(name, targetOptions, haxeOptions) {
         return __awaiter(this, void 0, Promise, function* () {
             fs.ensureDirSync(path.join(this.options.to, this.sysdir()));
-            let haxeOptions = this.haxeOptions(name, defines);
-            HaxeProject_1.writeHaxeProject(this.options.to, haxeOptions);
-            return haxeOptions;
+            HaxeProject_2.hxml(this.options.to, haxeOptions);
+            if (this.projectFiles) {
+                HaxeProject_1.writeHaxeProject(this.options.to, haxeOptions);
+            }
         });
     }
     copySound(platform, from, to) {

--- a/out/HaxeProject.js
+++ b/out/HaxeProject.js
@@ -137,6 +137,7 @@ function hxml(projectdir, options) {
     data += '-main Main' + '\n';
     fs.outputFileSync(path.join(projectdir, 'project-' + options.system + '.hxml'), data);
 }
+exports.hxml = hxml;
 function FlashDevelop(projectdir, options) {
     let platform;
     switch (options.language) {
@@ -381,11 +382,8 @@ function FlashDevelop(projectdir, options) {
     XmlWriter_1.writeXml(project, path.join(projectdir, 'project-' + options.system + '.hxproj'));
 }
 function writeHaxeProject(projectdir, options) {
-    options.defines.push('kha');
-    options.defines.push('kha_version=1607');
     FlashDevelop(projectdir, options);
     IntelliJ(projectdir, options);
-    hxml(projectdir, options);
 }
 exports.writeHaxeProject = writeHaxeProject;
 //# sourceMappingURL=HaxeProject.js.map

--- a/out/khamake.js
+++ b/out/khamake.js
@@ -111,6 +111,11 @@ var options = [
         default: ''
     },
     {
+        full: 'noproject',
+        description: 'Only source files. Don\'t generate project files.',
+        value: false,
+    },
+    {
         full: 'embedflashassets',
         description: 'Embed assets in swf for flash target',
         value: false

--- a/out/main.js
+++ b/out/main.js
@@ -44,11 +44,14 @@ function fixName(name) {
 function exportProjectFiles(name, options, exporter, kore, korehl, libraries, targetOptions, defines) {
     return __awaiter(this, void 0, Promise, function* () {
         if (options.haxe !== '') {
-            let haxeoptions = yield exporter.exportSolution(name, targetOptions, defines);
-            let compiler = new HaxeCompiler_1.HaxeCompiler(options.to, haxeoptions.to, haxeoptions.realto, options.haxe, 'project-' + exporter.sysdir() + '.hxml', ['Sources']);
+            let haxeOptions = exporter.haxeOptions(name, targetOptions, defines);
+            //haxeOptions.defines.push('kha');
+            //haxeOptions.defines.push('kha_version=1607');
+            yield exporter.exportSolution(name, targetOptions, haxeOptions);
+            let compiler = new HaxeCompiler_1.HaxeCompiler(options.to, haxeOptions.to, haxeOptions.realto, options.haxe, 'project-' + exporter.sysdir() + '.hxml', ['Sources']);
             yield compiler.run(options.watch);
         }
-        if (options.haxe !== '' && kore) {
+        if (options.haxe !== '' && kore && !options.noproject) {
             // If target is a Kore project, generate additional project folders here.
             // generate the korefile.js
             {
@@ -119,7 +122,7 @@ function exportProjectFiles(name, options, exporter, kore, korehl, libraries, ta
                 return name;
             }
         }
-        else if (options.haxe !== '' && korehl) {
+        else if (options.haxe !== '' && korehl && !options.noproject) {
             // If target is a Kore project, generate additional project folders here.
             // generate the korefile.js
             {


### PR DESCRIPTION
Project file generation can cause issues while running an IDE like Android Studio.
Usually we only need to update source files so I added --noproject.