### PR TITLE
allow to set a destination path and md5sum for exporting asset

### DIFF
--- a/out/AssetConverter.js
+++ b/out/AssetConverter.js
@@ -7,36 +7,50 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments)).next());
     });
 };
+const fs = require('fs');
 const path = require('path');
 const log = require('./log');
 const chokidar = require('chokidar');
+const crypto = require('crypto');
 class AssetConverter {
     constructor(exporter, platform, assetMatchers) {
         this.exporter = exporter;
         this.platform = platform;
         this.assetMatchers = assetMatchers;
     }
-    static createName(fileinfo, keepextension, options, from) {
-        if (options.name) {
-            let name = options.name;
-            let basePath = options.nameBaseDir ? path.join(from, options.nameBaseDir) : from;
-            let dirValue = path.relative(basePath, fileinfo.dir);
-            if (basePath.length > 0
-                && basePath[basePath.length - 1] == path.sep
-                && dirValue.length > 0
-                && dirValue[dirValue.length - 1] != path.sep)
-                dirValue += path.sep;
-            if (options.namePathSeparator)
-                dirValue = dirValue.split(path.sep).join(options.namePathSeparator);
-            let nameValue = fileinfo.name;
-            if (keepextension && name.indexOf("{ext}") < 0)
-                nameValue += fileinfo.ext;
-            return name.replace(/{name}/g, nameValue).replace(/{ext}/g, fileinfo.ext).replace(/{dir}/g, dirValue);
+    static replacePattern(pattern, value, fileinfo, options, from) {
+        let basePath = options.nameBaseDir ? path.join(from, options.nameBaseDir) : from;
+        let dirValue = path.relative(basePath, fileinfo.dir);
+        if (basePath.length > 0
+            && basePath[basePath.length - 1] == path.sep
+            && dirValue.length > 0
+            && dirValue[dirValue.length - 1] != path.sep)
+            dirValue += path.sep;
+        if (options.namePathSeparator)
+            dirValue = dirValue.split(path.sep).join(options.namePathSeparator);
+        return pattern.replace(/{name}/g, value).replace(/{ext}/g, fileinfo.ext).replace(/{dir}/g, dirValue);
+    }
+    static createExportInfo(fileinfo, keepextension, options, from) {
+        let nameValue = fileinfo.name;
+        let destination = fileinfo.name;
+        if (options.md5sum) {
+            let data = fs.readFileSync(path.join(fileinfo.dir, fileinfo.base));
+            let md5sum = crypto.createHash('md5').update(data).digest("hex"); //TODO yield generateMd5Sum(file);
+            destination += "_" + md5sum;
         }
-        else if (keepextension)
-            return fileinfo.name + fileinfo.ext;
-        else
-            return fileinfo.name;
+        if (keepextension && (!options.destination || options.destination.indexOf("{ext}") < 0)) {
+            destination += fileinfo.ext;
+        }
+        if (options.destination) {
+            destination = AssetConverter.replacePattern(options.destination, destination, fileinfo, options, from);
+        }
+        if (keepextension && (!options.name || options.name.indexOf("{ext}") < 0)) {
+            nameValue += fileinfo.ext;
+        }
+        if (options.name) {
+            nameValue = AssetConverter.replacePattern(options.name, nameValue, fileinfo, options, from);
+        }
+        return { name: nameValue, destination: destination };
     }
     watch(watch, match, options) {
         return new Promise((resolve, reject) => {
@@ -70,36 +84,36 @@ class AssetConverter {
                         case '.jpg':
                         case '.jpeg':
                         case '.hdr': {
-                            let name = AssetConverter.createName(fileinfo, false, options, this.exporter.options.from);
-                            let images = yield this.exporter.copyImage(this.platform, file, name, options);
-                            parsedFiles.push({ name: name, from: file, type: 'image', files: images, original_width: options.original_width, original_height: options.original_height });
+                            let exportInfo = AssetConverter.createExportInfo(fileinfo, false, options, this.exporter.options.from);
+                            let images = yield this.exporter.copyImage(this.platform, file, exportInfo.destination, options);
+                            parsedFiles.push({ name: exportInfo.name, from: file, type: 'image', files: images, original_width: options.original_width, original_height: options.original_height });
                             break;
                         }
                         case '.wav': {
-                            let name = AssetConverter.createName(fileinfo, false, options, this.exporter.options.from);
-                            let sounds = yield this.exporter.copySound(this.platform, file, name);
-                            parsedFiles.push({ name: name, from: file, type: 'sound', files: sounds, original_width: undefined, original_height: undefined });
+                            let exportInfo = AssetConverter.createExportInfo(fileinfo, false, options, this.exporter.options.from);
+                            let sounds = yield this.exporter.copySound(this.platform, file, exportInfo.destination);
+                            parsedFiles.push({ name: exportInfo.name, from: file, type: 'sound', files: sounds, original_width: undefined, original_height: undefined });
                             break;
                         }
                         case '.ttf': {
-                            let name = AssetConverter.createName(fileinfo, false, options, this.exporter.options.from);
-                            let fonts = yield this.exporter.copyFont(this.platform, file, name);
-                            parsedFiles.push({ name: name, from: file, type: 'font', files: fonts, original_width: undefined, original_height: undefined });
+                            let exportInfo = AssetConverter.createExportInfo(fileinfo, false, options, this.exporter.options.from);
+                            let fonts = yield this.exporter.copyFont(this.platform, file, exportInfo.destination);
+                            parsedFiles.push({ name: exportInfo.name, from: file, type: 'font', files: fonts, original_width: undefined, original_height: undefined });
                             break;
                         }
                         case '.mp4':
                         case '.webm':
                         case '.wmv':
                         case '.avi': {
-                            let name = AssetConverter.createName(fileinfo, false, options, this.exporter.options.from);
-                            let videos = yield this.exporter.copyVideo(this.platform, file, name);
-                            parsedFiles.push({ name: name, from: file, type: 'video', files: videos, original_width: undefined, original_height: undefined });
+                            let exportInfo = AssetConverter.createExportInfo(fileinfo, false, options, this.exporter.options.from);
+                            let videos = yield this.exporter.copyVideo(this.platform, file, exportInfo.destination);
+                            parsedFiles.push({ name: exportInfo.name, from: file, type: 'video', files: videos, original_width: undefined, original_height: undefined });
                             break;
                         }
                         default: {
-                            let name = AssetConverter.createName(fileinfo, true, options, this.exporter.options.from);
-                            let blobs = yield this.exporter.copyBlob(this.platform, file, name);
-                            parsedFiles.push({ name: name, from: file, type: 'blob', files: blobs, original_width: undefined, original_height: undefined });
+                            let exportInfo = AssetConverter.createExportInfo(fileinfo, true, options, this.exporter.options.from);
+                            let blobs = yield this.exporter.copyBlob(this.platform, file, exportInfo.destination);
+                            parsedFiles.push({ name: exportInfo.name, from: file, type: 'blob', files: blobs, original_width: undefined, original_height: undefined });
                             break;
                         }
                     }

--- a/out/ShaderCompiler.js
+++ b/out/ShaderCompiler.js
@@ -149,7 +149,7 @@ class ShaderCompiler {
                         reject(error);
                         return;
                     }
-                    parsedShaders.push({ files: [parsed.name + '.' + this.type], name: AssetConverter_1.AssetConverter.createName(parsed, false, options, this.exporter.options.from) });
+                    parsedShaders.push({ files: [parsed.name + '.' + this.type], name: AssetConverter_1.AssetConverter.createExportInfo(parsed, false, options, this.exporter.options.from).name });
                     ++index;
                 }
                 resolve(parsedShaders);

--- a/src/AssetConverter.ts
+++ b/src/AssetConverter.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import {KhaExporter} from './Exporters/KhaExporter';
 import * as log from './log';
 import * as chokidar from 'chokidar';
+import * as crypto from 'crypto'
 
 export class AssetConverter {
 	exporter: KhaExporter;
@@ -15,26 +16,47 @@ export class AssetConverter {
 		this.platform = platform;
 		this.assetMatchers = assetMatchers;
 	}
+
+	static replacePattern(pattern : string, value : string, fileinfo: path.ParsedPath, options: any, from : string){		
+		let basePath: string = options.nameBaseDir ? path.join(from, options.nameBaseDir) : from;
+		let dirValue: string = path.relative(basePath, fileinfo.dir);
+		if (basePath.length > 0 
+				&& basePath[basePath.length - 1] == path.sep 
+				&& dirValue.length > 0
+				&& dirValue[dirValue.length - 1] != path.sep) 
+						dirValue += path.sep;
+		if (options.namePathSeparator)
+				dirValue = dirValue.split(path.sep).join(options.namePathSeparator);
+		return pattern.replace(/{name}/g, value).replace(/{ext}/g, fileinfo.ext).replace(/{dir}/g, dirValue);
+	}
 	
-	static createName(fileinfo: path.ParsedPath, keepextension: boolean, options: any, from: string): string {
-		if (options.name) {
-			let name: string = options.name;
-			let basePath: string = options.nameBaseDir ? path.join(from, options.nameBaseDir) : from;
-			let dirValue: string = path.relative(basePath, fileinfo.dir);
-            if (basePath.length > 0 
-                && basePath[basePath.length - 1] == path.sep 
-                && dirValue.length > 0
-                && dirValue[dirValue.length - 1] != path.sep) 
-                    dirValue += path.sep;
-            if (options.namePathSeparator)
-                dirValue = dirValue.split(path.sep).join(options.namePathSeparator);
-			let nameValue = fileinfo.name;
-			if(keepextension && name.indexOf("{ext}") < 0)
-				nameValue += fileinfo.ext;
-			return name.replace(/{name}/g, nameValue).replace(/{ext}/g, fileinfo.ext).replace(/{dir}/g, dirValue);
+	static createExportInfo(fileinfo: path.ParsedPath, keepextension: boolean, options: any, from: string): {name:string,destination:string} {
+		let nameValue = fileinfo.name;
+		
+		let destination = fileinfo.name;
+
+		if(options.md5sum){
+			let data = fs.readFileSync(path.join(fileinfo.dir,fileinfo.base));
+			let md5sum = crypto.createHash('md5').update(data).digest("hex"); //TODO yield generateMd5Sum(file);
+			destination+="_"+md5sum;
 		}
-		else if (keepextension) return fileinfo.name + fileinfo.ext;
-		else return fileinfo.name;
+		if(keepextension && (!options.destination || options.destination.indexOf("{ext}") < 0)){
+			destination += fileinfo.ext;
+		}
+
+		if (options.destination) {
+			destination = AssetConverter.replacePattern(options.destination,destination,fileinfo,options,from);
+		}		
+	
+		if(keepextension && (!options.name || options.name.indexOf("{ext}") < 0)){
+			nameValue += fileinfo.ext;
+		}
+
+		if (options.name) {
+			nameValue = AssetConverter.replacePattern(options.name,nameValue,fileinfo,options,from);
+		}
+
+		return {name:nameValue,destination:destination};
 	}
 	
 	watch(watch: boolean, match: string, options: any): Promise<{ name: string, from: string, type: string, files: string[], original_width:number, original_height:number }[]> {
@@ -72,36 +94,36 @@ export class AssetConverter {
 						case '.jpg':
 						case '.jpeg':
 						case '.hdr': {
-							let name = AssetConverter.createName(fileinfo, false, options, this.exporter.options.from);
-							let images = await this.exporter.copyImage(this.platform, file, name, options);
-							parsedFiles.push({ name: name, from: file, type: 'image', files: images, original_width:options.original_width, original_height:options.original_height });
+							let exportInfo = AssetConverter.createExportInfo(fileinfo, false, options, this.exporter.options.from);
+							let images = await this.exporter.copyImage(this.platform, file, exportInfo.destination, options);
+							parsedFiles.push({ name: exportInfo.name, from: file, type: 'image', files: images, original_width:options.original_width, original_height:options.original_height });
 							break;
 						}
 						case '.wav': {
-							let name = AssetConverter.createName(fileinfo, false, options, this.exporter.options.from);
-							let sounds = await this.exporter.copySound(this.platform, file, name);
-							parsedFiles.push({ name: name, from: file, type: 'sound', files: sounds, original_width:undefined, original_height:undefined });
+							let exportInfo = AssetConverter.createExportInfo(fileinfo, false, options, this.exporter.options.from);
+							let sounds = await this.exporter.copySound(this.platform, file, exportInfo.destination);
+							parsedFiles.push({ name: exportInfo.name, from: file, type: 'sound', files: sounds, original_width:undefined, original_height:undefined });
 							break;
 						}
 						case '.ttf': {
-							let name = AssetConverter.createName(fileinfo, false, options, this.exporter.options.from);
-							let fonts = await this.exporter.copyFont(this.platform, file, name);
-							parsedFiles.push({ name: name, from: file, type: 'font', files: fonts, original_width:undefined, original_height:undefined });
+							let exportInfo = AssetConverter.createExportInfo(fileinfo, false, options, this.exporter.options.from);
+							let fonts = await this.exporter.copyFont(this.platform, file, exportInfo.destination);
+							parsedFiles.push({ name: exportInfo.name, from: file, type: 'font', files: fonts, original_width:undefined, original_height:undefined });
 							break;
 						}
 						case '.mp4':
 						case '.webm':
 						case '.wmv':
 						case '.avi': {
-							let name = AssetConverter.createName(fileinfo, false, options, this.exporter.options.from);
-							let videos = await this.exporter.copyVideo(this.platform, file, name);
-							parsedFiles.push({ name: name, from: file, type: 'video', files: videos, original_width:undefined, original_height:undefined });
+							let exportInfo = AssetConverter.createExportInfo(fileinfo, false, options, this.exporter.options.from);
+							let videos = await this.exporter.copyVideo(this.platform, file, exportInfo.destination);
+							parsedFiles.push({ name: exportInfo.name, from: file, type: 'video', files: videos, original_width:undefined, original_height:undefined });
 							break;
 						}
 						default: {
-							let name = AssetConverter.createName(fileinfo, true, options, this.exporter.options.from);
-							let blobs = await this.exporter.copyBlob(this.platform, file, name);
-							parsedFiles.push({ name: name, from: file, type: 'blob', files: blobs, original_width:undefined, original_height:undefined });
+							let exportInfo = AssetConverter.createExportInfo(fileinfo, true, options, this.exporter.options.from);
+							let blobs = await this.exporter.copyBlob(this.platform, file, exportInfo.destination);
+							parsedFiles.push({ name: exportInfo.name, from: file, type: 'blob', files: blobs, original_width:undefined, original_height:undefined });
 							break;
 						}
 					}

--- a/src/ShaderCompiler.ts
+++ b/src/ShaderCompiler.ts
@@ -154,7 +154,7 @@ export class ShaderCompiler {
 						reject(error);
 						return;
 					}
-					parsedShaders.push({ files: [parsed.name + '.' + this.type], name: AssetConverter.createName(parsed, false, options, this.exporter.options.from)});
+					parsedShaders.push({ files: [parsed.name + '.' + this.type], name: AssetConverter.createExportInfo(parsed, false, options, this.exporter.options.from).name});
 					++index;
 				}
 				resolve(parsedShaders);


### PR DESCRIPTION
As discussed in an earlier chat on irc, this allow to specify where the asset will be stored, this is useful if the files needs to be in a specific folder for example.

It also allow you to add an md5sum automatically. This is very useful for CDN env on the web.

example:
```
project.addAssets('Assets/', { name: '{name}', destination:'static/{name}', md5sum:true });
```