### PR TITLE
Various small fixes to khamake's '--watch' option.

### DIFF
--- a/out/HaxeCompiler.js
+++ b/out/HaxeCompiler.js
@@ -84,6 +84,8 @@ class HaxeCompiler {
         });
     }
     triggerCompilationServer() {
+        this.ready = false;
+        this.todo = false;
         return new Promise((resolve, reject) => {
             let exe = 'haxe';
             let env = process.env;

--- a/out/HaxeCompiler.js
+++ b/out/HaxeCompiler.js
@@ -114,14 +114,14 @@ class HaxeCompiler {
                     fs.renameSync(path.join('build', this.temp), path.join('build', this.to));
                 }
                 this.ready = true;
-                if (this.todo) {
-                    this.scheduleCompile();
-                }
                 console.log('Haxe compile end.');
                 if (code === 0)
                     resolve();
                 else
                     reject('Haxe compiler error.');
+                if (this.todo) {
+                    this.scheduleCompile();
+                }
             });
         });
     }

--- a/out/main.js
+++ b/out/main.js
@@ -100,7 +100,7 @@ function exportProjectFiles(name, options, exporter, kore, korehl, libraries, ta
                 haxeOptions.parameters.push('-debug');
             }
             HaxeProject_1.writeHaxeProject(options.to, haxeOptions);
-            let compiler = new HaxeCompiler_1.HaxeCompiler(options.to, haxeOptions.to, haxeOptions.realto, options.haxe, haxeOptions.safeName + '-' + exporter.sysdir() + '.hxml', ['Sources']);
+            let compiler = new HaxeCompiler_1.HaxeCompiler(options.to, haxeOptions.to, haxeOptions.realto, options.haxe, haxeOptions.safeName + '-' + exporter.sysdir() + '.hxml', haxeOptions.sources);
             yield compiler.run(options.watch);
             yield exporter.export(name, targetOptions, haxeOptions);
         }

--- a/src/HaxeCompiler.ts
+++ b/src/HaxeCompiler.ts
@@ -88,6 +88,8 @@ export class HaxeCompiler {
 	}
 	
 	triggerCompilationServer() {
+		this.ready = false;
+		this.todo = false;
 		return new Promise((resolve, reject) => {
 			let exe = 'haxe';
 			let env = process.env;

--- a/src/HaxeCompiler.ts
+++ b/src/HaxeCompiler.ts
@@ -119,12 +119,12 @@ export class HaxeCompiler {
 					fs.renameSync(path.join('build', this.temp), path.join('build', this.to));
 				}
 				this.ready = true;
-				if (this.todo) {
-					this.scheduleCompile();
-				}
 				console.log('Haxe compile end.');
 				if (code === 0) resolve();
 				else reject('Haxe compiler error.')
+				if (this.todo) {
+					this.scheduleCompile();
+				}
 			});
 		});
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -110,7 +110,7 @@ async function exportProjectFiles(name: string, options: Options, exporter: KhaE
 
 		writeHaxeProject(options.to, haxeOptions);
 
-		let compiler = new HaxeCompiler(options.to, haxeOptions.to, haxeOptions.realto, options.haxe, haxeOptions.safeName + '-' + exporter.sysdir() + '.hxml', ['Sources']);
+		let compiler = new HaxeCompiler(options.to, haxeOptions.to, haxeOptions.realto, options.haxe, haxeOptions.safeName + '-' + exporter.sysdir() + '.hxml', haxeOptions.sources);
 		await compiler.run(options.watch);
 
 		await exporter.export(name, targetOptions, haxeOptions);


### PR DESCRIPTION
1. Pass real source directories to HaxeCompiler class instead of hardcoded ['Sources'].
2. Setting HaxeCompiler::todo and HaxeCompiler::ready to false when apropriate. Otherwise leaded to infinite cycles and multiple simultaneous compiler runs.
3. Rearrange messages so that 'Haxe compiler start' of the next compiler run goes after 'Haxe compiler end' of the current compiler run.