### PR TITLE
HTML5 target option for custom canvas ID 

### DIFF
--- a/Data/html5/index.html
+++ b/Data/html5/index.html
@@ -5,7 +5,7 @@
 	<title>{Name}</title>
 </head>
 <body>
-	<canvas id="khanvas" width="{Width}" height="{Height}"></canvas>
+	<canvas id="{CanvasId}" width="{Width}" height="{Height}"></canvas>
 	<script src="kha.js"></script>
 </body>
 </html>

--- a/out/Exporters/Html5Exporter.js
+++ b/out/Exporters/Html5Exporter.js
@@ -34,7 +34,7 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
         defines.push('sys_a1');
         defines.push('sys_a2');
         let canvasId = targetOptions.html5.canvasId == null ? 'khanvas' : targetOptions.html5.canvasId;
-        defines.push('canvasId="' + canvasId + '"');
+        defines.push('canvasId=' + canvasId);
         let webgl = targetOptions.html5.webgl == null ? true : targetOptions.html5.webgl;
         if (webgl) {
             defines.push('webgl');

--- a/out/Exporters/Html5Exporter.js
+++ b/out/Exporters/Html5Exporter.js
@@ -33,6 +33,8 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
         defines.push('sys_g4');
         defines.push('sys_a1');
         defines.push('sys_a2');
+        let canvasId = targetOptions.html5.canvasId == null ? 'khanvas' : targetOptions.html5.canvasId;
+        defines.push('canvasId="' + canvasId + '"');
         let webgl = targetOptions.html5.webgl == null ? true : targetOptions.html5.webgl;
         if (webgl) {
             defines.push('webgl');
@@ -64,8 +66,16 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
             name: name
         };
     }
-    export(name, targetOptions, haxeOptions) {
+    export(name, _targetOptions, haxeOptions) {
         return __awaiter(this, void 0, void 0, function* () {
+            let targetOptions = {
+                canvasId: 'khanvas'
+            };
+            if (_targetOptions != null && _targetOptions.html5 != null) {
+                let userOptions = _targetOptions.html5;
+                if (userOptions.canvasId != null)
+                    targetOptions.canvasId = userOptions.canvasId;
+            }
             fs.ensureDirSync(path.join(this.options.to, this.sysdir()));
             if (this.isDebugHtml5()) {
                 let index = path.join(this.options.to, this.sysdir(), 'index.html');
@@ -74,6 +84,7 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
                     protoindex = protoindex.replace(/{Name}/g, name);
                     protoindex = protoindex.replace(/{Width}/g, '' + this.width);
                     protoindex = protoindex.replace(/{Height}/g, '' + this.height);
+                    protoindex = protoindex.replace(/{CanvasId}/g, '' + targetOptions.canvasId);
                     fs.writeFileSync(index.toString(), protoindex);
                 }
                 let pack = path.join(this.options.to, this.sysdir(), 'package.json');
@@ -101,6 +112,7 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
                     protoindex = protoindex.replace(/{Name}/g, name);
                     protoindex = protoindex.replace(/{Width}/g, '' + this.width);
                     protoindex = protoindex.replace(/{Height}/g, '' + this.height);
+                    protoindex = protoindex.replace(/{CanvasId}/g, '' + targetOptions.canvasId);
                     fs.writeFileSync(index.toString(), protoindex);
                 }
             }

--- a/out/Exporters/Html5Exporter.js
+++ b/out/Exporters/Html5Exporter.js
@@ -33,8 +33,8 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
         defines.push('sys_g4');
         defines.push('sys_a1');
         defines.push('sys_a2');
-        let canvasId = targetOptions.html5.canvasId == null ? 'khanvas' : targetOptions.html5.canvasId;
-        defines.push('canvasId=' + canvasId);
+        let canvas_id = targetOptions.html5.canvas_id == null ? 'khanvas' : targetOptions.html5.canvas_id;
+        defines.push('canvas_id=' + canvas_id);
         let webgl = targetOptions.html5.webgl == null ? true : targetOptions.html5.webgl;
         if (webgl) {
             defines.push('webgl');
@@ -69,12 +69,12 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
     export(name, _targetOptions, haxeOptions) {
         return __awaiter(this, void 0, void 0, function* () {
             let targetOptions = {
-                canvasId: 'khanvas'
+                canvas_id: 'khanvas'
             };
             if (_targetOptions != null && _targetOptions.html5 != null) {
                 let userOptions = _targetOptions.html5;
-                if (userOptions.canvasId != null)
-                    targetOptions.canvasId = userOptions.canvasId;
+                if (userOptions.canvas_id != null)
+                    targetOptions.canvas_id = userOptions.canvas_id;
             }
             fs.ensureDirSync(path.join(this.options.to, this.sysdir()));
             if (this.isDebugHtml5()) {
@@ -84,7 +84,7 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
                     protoindex = protoindex.replace(/{Name}/g, name);
                     protoindex = protoindex.replace(/{Width}/g, '' + this.width);
                     protoindex = protoindex.replace(/{Height}/g, '' + this.height);
-                    protoindex = protoindex.replace(/{CanvasId}/g, '' + targetOptions.canvasId);
+                    protoindex = protoindex.replace(/{CanvasId}/g, '' + targetOptions.canvas_id);
                     fs.writeFileSync(index.toString(), protoindex);
                 }
                 let pack = path.join(this.options.to, this.sysdir(), 'package.json');
@@ -112,7 +112,7 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
                     protoindex = protoindex.replace(/{Name}/g, name);
                     protoindex = protoindex.replace(/{Width}/g, '' + this.width);
                     protoindex = protoindex.replace(/{Height}/g, '' + this.height);
-                    protoindex = protoindex.replace(/{CanvasId}/g, '' + targetOptions.canvasId);
+                    protoindex = protoindex.replace(/{CanvasId}/g, '' + targetOptions.canvas_id);
                     fs.writeFileSync(index.toString(), protoindex);
                 }
             }

--- a/src/Exporters/Html5Exporter.ts
+++ b/src/Exporters/Html5Exporter.ts
@@ -38,7 +38,8 @@ export class Html5Exporter extends KhaExporter {
 		defines.push('sys_a2');
 
 		let canvasId = targetOptions.html5.canvasId == null ? 'khanvas' : targetOptions.html5.canvasId;
-		defines.push('canvasId="' + canvasId + '"');
+		
+		defines.push('canvasId=' + canvasId);
 
 		let webgl = targetOptions.html5.webgl == null ? true : targetOptions.html5.webgl;
 

--- a/src/Exporters/Html5Exporter.ts
+++ b/src/Exporters/Html5Exporter.ts
@@ -37,9 +37,9 @@ export class Html5Exporter extends KhaExporter {
 		defines.push('sys_a1');
 		defines.push('sys_a2');
 
-		let canvasId = targetOptions.html5.canvasId == null ? 'khanvas' : targetOptions.html5.canvasId;
+		let canvas_id = targetOptions.html5.canvas_id == null ? 'khanvas' : targetOptions.html5.canvas_id;
 		
-		defines.push('canvasId=' + canvasId);
+		defines.push('canvas_id=' + canvas_id);
 
 		let webgl = targetOptions.html5.webgl == null ? true : targetOptions.html5.webgl;
 
@@ -79,12 +79,12 @@ export class Html5Exporter extends KhaExporter {
 
 	async export(name: string, _targetOptions: any, haxeOptions: any): Promise<void> {
 		let targetOptions = {
-			canvasId: 'khanvas'
+			canvas_id: 'khanvas'
 		};
 
 		if (_targetOptions != null && _targetOptions.html5 != null) {
 			let userOptions = _targetOptions.html5;
-			if (userOptions.canvasId != null) targetOptions.canvasId = userOptions.canvasId;
+			if (userOptions.canvas_id != null) targetOptions.canvas_id = userOptions.canvas_id;
 		}
 
 		fs.ensureDirSync(path.join(this.options.to, this.sysdir()));
@@ -96,7 +96,7 @@ export class Html5Exporter extends KhaExporter {
 				protoindex = protoindex.replace(/{Name}/g, name);
 				protoindex = protoindex.replace(/{Width}/g, '' + this.width);
 				protoindex = protoindex.replace(/{Height}/g, '' + this.height);
-				protoindex = protoindex.replace(/{CanvasId}/g, '' + targetOptions.canvasId);
+				protoindex = protoindex.replace(/{CanvasId}/g, '' + targetOptions.canvas_id);
 				fs.writeFileSync(index.toString(), protoindex);
 			}
 
@@ -127,7 +127,7 @@ export class Html5Exporter extends KhaExporter {
 				protoindex = protoindex.replace(/{Name}/g, name);
 				protoindex = protoindex.replace(/{Width}/g, '' + this.width);
 				protoindex = protoindex.replace(/{Height}/g, '' + this.height);
-				protoindex = protoindex.replace(/{CanvasId}/g, '' + targetOptions.canvasId);
+				protoindex = protoindex.replace(/{CanvasId}/g, '' + targetOptions.canvas_id);
 				fs.writeFileSync(index.toString(), protoindex);
 			}
 		}

--- a/src/Exporters/Html5Exporter.ts
+++ b/src/Exporters/Html5Exporter.ts
@@ -37,6 +37,9 @@ export class Html5Exporter extends KhaExporter {
 		defines.push('sys_a1');
 		defines.push('sys_a2');
 
+		let canvasId = targetOptions.html5.canvasId == null ? 'khanvas' : targetOptions.html5.canvasId;
+		defines.push('canvasId="' + canvasId + '"');
+
 		let webgl = targetOptions.html5.webgl == null ? true : targetOptions.html5.webgl;
 
 		if (webgl) {
@@ -73,7 +76,16 @@ export class Html5Exporter extends KhaExporter {
 		};
 	}
 
-	async export(name: string, targetOptions: any, haxeOptions: any): Promise<void> {
+	async export(name: string, _targetOptions: any, haxeOptions: any): Promise<void> {
+		let targetOptions = {
+			canvasId: 'khanvas'
+		};
+
+		if (_targetOptions != null && _targetOptions.html5 != null) {
+			let userOptions = _targetOptions.html5;
+			if (userOptions.canvasId != null) targetOptions.canvasId = userOptions.canvasId;
+		}
+
 		fs.ensureDirSync(path.join(this.options.to, this.sysdir()));
 
 		if (this.isDebugHtml5()) {
@@ -83,6 +95,7 @@ export class Html5Exporter extends KhaExporter {
 				protoindex = protoindex.replace(/{Name}/g, name);
 				protoindex = protoindex.replace(/{Width}/g, '' + this.width);
 				protoindex = protoindex.replace(/{Height}/g, '' + this.height);
+				protoindex = protoindex.replace(/{CanvasId}/g, '' + targetOptions.canvasId);
 				fs.writeFileSync(index.toString(), protoindex);
 			}
 
@@ -113,6 +126,7 @@ export class Html5Exporter extends KhaExporter {
 				protoindex = protoindex.replace(/{Name}/g, name);
 				protoindex = protoindex.replace(/{Width}/g, '' + this.width);
 				protoindex = protoindex.replace(/{Height}/g, '' + this.height);
+				protoindex = protoindex.replace(/{CanvasId}/g, '' + targetOptions.canvasId);
 				fs.writeFileSync(index.toString(), protoindex);
 			}
 		}


### PR DESCRIPTION
The JS scripts built by Kha target canvas elements with the "khanvas" ID by default. Because the ID is hardcoded, it is not possible to express that the script should target a different element instead.

The motivation for this change is to allow for more HTML5 Kha projects to be present on the same page, by letting them target canvas elements with different IDs.

The changes proposed in this pull request introduce a new HTML5 target option to `khafile.js` - `canvasId` - which sets the target canvas ID. This option's value defaults to the previously defined "khanvas" if no ID is provided. It is only applied for HTML5 release builds. The option is used as follows:

`project.targetOptions.html5.canvasId = 'my-custom-id';`

When set, the provided option is passed to the compiler as a value under the `canvasId` key (compiler flag), which can then be retrieved in the macro context.