### PR TITLE
HTML5 target option for script name (+ fix)

### DIFF
--- a/Data/html5/index.html
+++ b/Data/html5/index.html
@@ -6,6 +6,6 @@
 </head>
 <body>
 	<canvas id="{CanvasId}" width="{Width}" height="{Height}"></canvas>
-	<script src="kha.js"></script>
+	<script src="{ScriptName}.js"></script>
 </body>
 </html>

--- a/out/Exporters/Html5Exporter.js
+++ b/out/Exporters/Html5Exporter.js
@@ -33,8 +33,8 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
         defines.push('sys_g4');
         defines.push('sys_a1');
         defines.push('sys_a2');
-        let canvas_id = targetOptions.html5.canvas_id == null ? 'khanvas' : targetOptions.html5.canvas_id;
-        defines.push('canvas_id=' + canvas_id);
+        let canvasId = targetOptions.html5.canvasId == null ? 'khanvas' : targetOptions.html5.canvasId;
+        defines.push('canvas_id=' + canvasId);
         let scriptName = 'kha';
         if (targetOptions.html5.scriptName != null && !(this.isNode() || this.isDebugHtml5())) {
             scriptName = targetOptions.html5.scriptName;
@@ -74,13 +74,13 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
     export(name, _targetOptions, haxeOptions) {
         return __awaiter(this, void 0, void 0, function* () {
             let targetOptions = {
-                canvas_id: 'khanvas',
+                canvasId: 'khanvas',
                 scriptName: 'kha'
             };
             if (_targetOptions != null && _targetOptions.html5 != null) {
                 let userOptions = _targetOptions.html5;
-                if (userOptions.canvas_id != null)
-                    targetOptions.canvas_id = userOptions.canvas_id;
+                if (userOptions.canvasId != null)
+                    targetOptions.canvasId = userOptions.canvasId;
                 if (userOptions.scriptName != null)
                     targetOptions.scriptName = userOptions.scriptName;
             }
@@ -92,7 +92,7 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
                     protoindex = protoindex.replace(/{Name}/g, name);
                     protoindex = protoindex.replace(/{Width}/g, '' + this.width);
                     protoindex = protoindex.replace(/{Height}/g, '' + this.height);
-                    protoindex = protoindex.replace(/{CanvasId}/g, '' + targetOptions.canvas_id);
+                    protoindex = protoindex.replace(/{CanvasId}/g, '' + targetOptions.canvasId);
                     protoindex = protoindex.replace(/{ScriptName}/g, '' + targetOptions.scriptName);
                     fs.writeFileSync(index.toString(), protoindex);
                 }
@@ -121,7 +121,7 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
                     protoindex = protoindex.replace(/{Name}/g, name);
                     protoindex = protoindex.replace(/{Width}/g, '' + this.width);
                     protoindex = protoindex.replace(/{Height}/g, '' + this.height);
-                    protoindex = protoindex.replace(/{CanvasId}/g, '' + targetOptions.canvas_id);
+                    protoindex = protoindex.replace(/{CanvasId}/g, '' + targetOptions.canvasId);
                     protoindex = protoindex.replace(/{ScriptName}/g, '' + targetOptions.scriptName);
                     fs.writeFileSync(index.toString(), protoindex);
                 }

--- a/out/Exporters/Html5Exporter.js
+++ b/out/Exporters/Html5Exporter.js
@@ -35,6 +35,11 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
         defines.push('sys_a2');
         let canvas_id = targetOptions.html5.canvas_id == null ? 'khanvas' : targetOptions.html5.canvas_id;
         defines.push('canvas_id=' + canvas_id);
+        let scriptName = 'kha';
+        if (targetOptions.html5.scriptName != null && !(this.isNode() || this.isDebugHtml5())) {
+            scriptName = targetOptions.html5.scriptName;
+        }
+        defines.push('script_name=' + scriptName);
         let webgl = targetOptions.html5.webgl == null ? true : targetOptions.html5.webgl;
         if (webgl) {
             defines.push('webgl');
@@ -53,7 +58,7 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
         }
         return {
             from: this.options.from.toString(),
-            to: path.join(this.sysdir(), 'kha.js'),
+            to: path.join(this.sysdir(), scriptName + '.js'),
             sources: this.sources,
             libraries: this.libraries,
             defines: defines,
@@ -69,12 +74,15 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
     export(name, _targetOptions, haxeOptions) {
         return __awaiter(this, void 0, void 0, function* () {
             let targetOptions = {
-                canvas_id: 'khanvas'
+                canvas_id: 'khanvas',
+                scriptName: 'kha'
             };
             if (_targetOptions != null && _targetOptions.html5 != null) {
                 let userOptions = _targetOptions.html5;
                 if (userOptions.canvas_id != null)
                     targetOptions.canvas_id = userOptions.canvas_id;
+                if (userOptions.scriptName != null)
+                    targetOptions.scriptName = userOptions.scriptName;
             }
             fs.ensureDirSync(path.join(this.options.to, this.sysdir()));
             if (this.isDebugHtml5()) {
@@ -85,6 +93,7 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
                     protoindex = protoindex.replace(/{Width}/g, '' + this.width);
                     protoindex = protoindex.replace(/{Height}/g, '' + this.height);
                     protoindex = protoindex.replace(/{CanvasId}/g, '' + targetOptions.canvas_id);
+                    protoindex = protoindex.replace(/{ScriptName}/g, '' + targetOptions.scriptName);
                     fs.writeFileSync(index.toString(), protoindex);
                 }
                 let pack = path.join(this.options.to, this.sysdir(), 'package.json');
@@ -113,6 +122,7 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
                     protoindex = protoindex.replace(/{Width}/g, '' + this.width);
                     protoindex = protoindex.replace(/{Height}/g, '' + this.height);
                     protoindex = protoindex.replace(/{CanvasId}/g, '' + targetOptions.canvas_id);
+                    protoindex = protoindex.replace(/{ScriptName}/g, '' + targetOptions.scriptName);
                     fs.writeFileSync(index.toString(), protoindex);
                 }
             }

--- a/src/Exporters/Html5Exporter.ts
+++ b/src/Exporters/Html5Exporter.ts
@@ -41,6 +41,13 @@ export class Html5Exporter extends KhaExporter {
 		
 		defines.push('canvas_id=' + canvas_id);
 
+		let scriptName = 'kha';
+		if (targetOptions.html5.scriptName != null && !(this.isNode() || this.isDebugHtml5())) {
+			scriptName = targetOptions.html5.scriptName;
+		}
+
+		defines.push('script_name=' + scriptName);
+
 		let webgl = targetOptions.html5.webgl == null ? true : targetOptions.html5.webgl;
 
 		if (webgl) {
@@ -63,7 +70,7 @@ export class Html5Exporter extends KhaExporter {
 
 		return {
 			from: this.options.from.toString(),
-			to: path.join(this.sysdir(), 'kha.js'),
+			to: path.join(this.sysdir(), scriptName + '.js'),
 			sources: this.sources,
 			libraries: this.libraries,
 			defines: defines,
@@ -79,12 +86,14 @@ export class Html5Exporter extends KhaExporter {
 
 	async export(name: string, _targetOptions: any, haxeOptions: any): Promise<void> {
 		let targetOptions = {
-			canvas_id: 'khanvas'
+			canvas_id: 'khanvas',
+			scriptName: 'kha'
 		};
 
 		if (_targetOptions != null && _targetOptions.html5 != null) {
 			let userOptions = _targetOptions.html5;
 			if (userOptions.canvas_id != null) targetOptions.canvas_id = userOptions.canvas_id;
+			if (userOptions.scriptName != null) targetOptions.scriptName = userOptions.scriptName;
 		}
 
 		fs.ensureDirSync(path.join(this.options.to, this.sysdir()));
@@ -97,6 +106,7 @@ export class Html5Exporter extends KhaExporter {
 				protoindex = protoindex.replace(/{Width}/g, '' + this.width);
 				protoindex = protoindex.replace(/{Height}/g, '' + this.height);
 				protoindex = protoindex.replace(/{CanvasId}/g, '' + targetOptions.canvas_id);
+				protoindex = protoindex.replace(/{ScriptName}/g, '' + targetOptions.scriptName);
 				fs.writeFileSync(index.toString(), protoindex);
 			}
 
@@ -128,6 +138,7 @@ export class Html5Exporter extends KhaExporter {
 				protoindex = protoindex.replace(/{Width}/g, '' + this.width);
 				protoindex = protoindex.replace(/{Height}/g, '' + this.height);
 				protoindex = protoindex.replace(/{CanvasId}/g, '' + targetOptions.canvas_id);
+				protoindex = protoindex.replace(/{ScriptName}/g, '' + targetOptions.scriptName);
 				fs.writeFileSync(index.toString(), protoindex);
 			}
 		}

--- a/src/Exporters/Html5Exporter.ts
+++ b/src/Exporters/Html5Exporter.ts
@@ -37,9 +37,9 @@ export class Html5Exporter extends KhaExporter {
 		defines.push('sys_a1');
 		defines.push('sys_a2');
 
-		let canvas_id = targetOptions.html5.canvas_id == null ? 'khanvas' : targetOptions.html5.canvas_id;
+		let canvasId = targetOptions.html5.canvasId == null ? 'khanvas' : targetOptions.html5.canvasId;
 		
-		defines.push('canvas_id=' + canvas_id);
+		defines.push('canvas_id=' + canvasId);
 
 		let scriptName = 'kha';
 		if (targetOptions.html5.scriptName != null && !(this.isNode() || this.isDebugHtml5())) {
@@ -86,13 +86,13 @@ export class Html5Exporter extends KhaExporter {
 
 	async export(name: string, _targetOptions: any, haxeOptions: any): Promise<void> {
 		let targetOptions = {
-			canvas_id: 'khanvas',
+			canvasId: 'khanvas',
 			scriptName: 'kha'
 		};
 
 		if (_targetOptions != null && _targetOptions.html5 != null) {
 			let userOptions = _targetOptions.html5;
-			if (userOptions.canvas_id != null) targetOptions.canvas_id = userOptions.canvas_id;
+			if (userOptions.canvasId != null) targetOptions.canvasId = userOptions.canvasId;
 			if (userOptions.scriptName != null) targetOptions.scriptName = userOptions.scriptName;
 		}
 
@@ -105,7 +105,7 @@ export class Html5Exporter extends KhaExporter {
 				protoindex = protoindex.replace(/{Name}/g, name);
 				protoindex = protoindex.replace(/{Width}/g, '' + this.width);
 				protoindex = protoindex.replace(/{Height}/g, '' + this.height);
-				protoindex = protoindex.replace(/{CanvasId}/g, '' + targetOptions.canvas_id);
+				protoindex = protoindex.replace(/{CanvasId}/g, '' + targetOptions.canvasId);
 				protoindex = protoindex.replace(/{ScriptName}/g, '' + targetOptions.scriptName);
 				fs.writeFileSync(index.toString(), protoindex);
 			}
@@ -137,7 +137,7 @@ export class Html5Exporter extends KhaExporter {
 				protoindex = protoindex.replace(/{Name}/g, name);
 				protoindex = protoindex.replace(/{Width}/g, '' + this.width);
 				protoindex = protoindex.replace(/{Height}/g, '' + this.height);
-				protoindex = protoindex.replace(/{CanvasId}/g, '' + targetOptions.canvas_id);
+				protoindex = protoindex.replace(/{CanvasId}/g, '' + targetOptions.canvasId);
 				protoindex = protoindex.replace(/{ScriptName}/g, '' + targetOptions.scriptName);
 				fs.writeFileSync(index.toString(), protoindex);
 			}


### PR DESCRIPTION
The JS scripts generated by Kha always bear the same name - "kha.js". This name is hardcoded, which means that the generated scripts need to be renamed manually, if necessary.

The motivation for this change is to somewhat automate the process of (re)naming Kha project scripts.

The changes proposed in this pull request introduce a new HTML5 target option to `khafile.js` - `scriptName` - which sets the generated script's name (sans extension), defaulting to "kha" if no value is provided. This is only implemented for the HTML5 target, and not HTML5 Debug, HTML5 Worker, or Node targets. The option is used as follows:

`project.targetOptions.html5.scriptName = 'new-project';`

This will generate a script with the name `new-project.js` and use it in the default template. The option is also passed to the compiler as a value to the `script_name` flag, which can be retrieved in the macro context.

---

Additionally, a fix was made to the custom canvas ID target option. It was mistakenly renamed from `canvasId` to `canvas_id` during the conversion to  snake-case. To keep in line with the other target options, the option itself has again been renamed to `canvasId`, to conform with the camel-case style of other target options. The name of the define renames unchanged.